### PR TITLE
actual pixel perfect borders (with mouseanchor)

### DIFF
--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -33,6 +33,11 @@ end
 local modName = ...;
 local tt = CreateFrame("Frame",modName,UIParent,BackdropTemplateMixin and "BackdropTemplate");	-- 9.0.1: Using BackdropTemplate
 
+-- actual pixel perfect scale
+local ui_scale = UIParent:GetEffectiveScale()
+local height = select(2, GetPhysicalScreenSize())
+local ppScale = (768 / height) / ui_scale
+
 -- Global Chat Message Function
 function AzMsg(msg) DEFAULT_CHAT_FRAME:AddMessage(tostring(msg):gsub("|1","|cffffff80"):gsub("|2","|cffffffff"),0.5,0.75,1.0); end
 
@@ -561,9 +566,9 @@ end
 --                                              Settings                                              --
 --------------------------------------------------------------------------------------------------------
 
--- Get nearest pixel size (e.g. to avoid 1-pixel borders, which are sometimes 0/2-pixels wide)
+-- Get nearest pixel size (e.g. to avoid 1-pixel borders, which are sometimes 2-pixels wide)
 local function GetNearestPixelSize(size)
-	return PixelUtil.GetNearestPixelSize(size, cfg.gttScale);
+	return size * ppScale;
 end
 
 -- Resolves the given table array of string names into their global objects
@@ -905,8 +910,9 @@ end
 function tt:AnchorFrameToMouse(frame)
 	local x, y = GetCursorPosition();
 	local effScale = frame:GetEffectiveScale();
+	local offsetX, offsetY = cfg.mouseOffsetX * ppScale, cfg.mouseOffsetY * ppScale;
 	frame:ClearAllPoints();
-	frame:SetPoint(frame.ttAnchorPoint,UIParent,"BOTTOMLEFT",(x / effScale + cfg.mouseOffsetX),(y / effScale + cfg.mouseOffsetY));
+	frame:SetPoint(frame.ttAnchorPoint,UIParent,"BOTTOMLEFT",(x / effScale + offsetX),(y / effScale + offsetY));
 end
 
 -- Re-anchor for anchor type mouse

--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -567,8 +567,8 @@ end
 --------------------------------------------------------------------------------------------------------
 
 -- Get nearest pixel size (e.g. to avoid 1-pixel borders, which are sometimes 2-pixels wide)
-local function GetNearestPixelSize(size)
-	return size * ppScale;
+function tt:GetNearestPixelSize(size)
+	return (size * ppScale) / cfg.gttScale;
 end
 
 -- Resolves the given table array of string names into their global objects
@@ -646,11 +646,11 @@ function tt:ApplySettings()
 	end
 	tipBackdrop.tile = false;
 	tipBackdrop.tileEdge = false;
-	tipBackdrop.edgeSize = GetNearestPixelSize(cfg.backdropEdgeSize);
-	tipBackdrop.insets.left = GetNearestPixelSize(cfg.backdropInsets);
-	tipBackdrop.insets.right = GetNearestPixelSize(cfg.backdropInsets);
-	tipBackdrop.insets.top = GetNearestPixelSize(cfg.backdropInsets);
-	tipBackdrop.insets.bottom = GetNearestPixelSize(cfg.backdropInsets);
+	tipBackdrop.edgeSize = tt:GetNearestPixelSize(cfg.backdropEdgeSize);
+	tipBackdrop.insets.left = tt:GetNearestPixelSize(cfg.backdropInsets);
+	tipBackdrop.insets.right = tt:GetNearestPixelSize(cfg.backdropInsets);
+	tipBackdrop.insets.top = tt:GetNearestPixelSize(cfg.backdropInsets);
+	tipBackdrop.insets.bottom = tt:GetNearestPixelSize(cfg.backdropInsets);
 
 	tipBackdrop.backdropColor:SetRGBA(unpack(cfg.tipColor));
 	tipBackdrop.backdropBorderColor:SetRGBA(unpack(cfg.tipBorderColor));
@@ -910,7 +910,7 @@ end
 function tt:AnchorFrameToMouse(frame)
 	local x, y = GetCursorPosition();
 	local effScale = frame:GetEffectiveScale();
-	local offsetX, offsetY = cfg.mouseOffsetX * ppScale, cfg.mouseOffsetY * ppScale;
+	local offsetX, offsetY = tt:GetNearestPixelSize(cfg.mouseOffsetX), tt:GetNearestPixelSize(cfg.mouseOffsetY);
 	frame:ClearAllPoints();
 	frame:SetPoint(frame.ttAnchorPoint,UIParent,"BOTTOMLEFT",(x / effScale + offsetX),(y / effScale + offsetY));
 end


### PR DESCRIPTION
So, the current and former versions didn't have pixel perfect borders for me by default (1440p resolution). I tried the approach I use for some of my WeakAuras, and with this I get pixel perfect borders on every resolution, in every situation I tried (even randomly resizing in windowed mode (after a /reload ofc)). Theres also no text jumping when moving the mouse.
Please test it yourself and see if you can find any edge cases, otherwise I think this is better than the current approach.