### PR TITLE
borders for the item icon and aura icons + various options relating to that

### DIFF
--- a/TipTac/ttAuras.lua
+++ b/TipTac/ttAuras.lua
@@ -168,6 +168,7 @@ function ttAuras:OnApplyConfig(cfg)
 		if (cfg.showBuffs or cfg.showDebuffs) then
 			aura:SetSize(cfg.auraSize*ppScale,cfg.auraSize*ppScale);
 			aura.border:SetSize(cfg.auraSize*ppScale,cfg.auraSize*ppScale);
+			aura.border:Show();
 			aura.count:SetFont(gameFont,(cfg.auraSize*ppScale / 2),"OUTLINE");
 			aura.cooldown.noCooldownCount = cfg.noCooldownCount;
 		else

--- a/TipTac/ttAuras.lua
+++ b/TipTac/ttAuras.lua
@@ -42,20 +42,12 @@ local function CreateAuraFrame(parent)
 	aura.cooldown:SetFrameLevel(aura:GetFrameLevel());
 	aura.cooldown.noCooldownCount = cfg.noCooldownCount or nil;
 
-	if (cfg.auraCustomBorder) then
-		aura.border = CreateFrame("Frame", nil, aura, BackdropTemplateMixin and "BackdropTemplate");
-		aura.border:SetSize(cfg.auraSize*ppScale, cfg.auraSize*ppScale);
-		aura.border:SetPoint("CENTER", aura, "CENTER");
-		aura.border:SetBackdrop(parent.backdropInfo);
-		aura.border:SetBackdropColor(0, 0, 0, 0);
-		aura.border:SetFrameLevel(aura.cooldown:GetFrameLevel()+1);
-	else
-		aura.border = aura:CreateTexture(nil,"OVERLAY");
-		aura.border:SetPoint("TOPLEFT",-1,1);
-		aura.border:SetPoint("BOTTOMRIGHT",1,-1);
-		aura.border:SetTexture("Interface\\Buttons\\UI-Debuff-Overlays");
-		aura.border:SetTexCoord(0.296875,0.5703125,0,0.515625);
-	end
+	aura.border = CreateFrame("Frame", nil, aura, BackdropTemplateMixin and "BackdropTemplate");
+	aura.border:SetSize(cfg.auraSize*ppScale, cfg.auraSize*ppScale);
+	aura.border:SetPoint("CENTER", aura, "CENTER");
+	aura.border:SetBackdrop(aura:GetParent().backdropInfo);
+	aura.border:SetBackdropColor(0, 0, 0, 0);
+	aura.border:SetFrameLevel(aura.cooldown:GetFrameLevel()+1);
 
 	auras[#auras + 1] = aura;
 	return aura;
@@ -127,8 +119,7 @@ function ttAuras:DisplayAuras(tip,auraType,startingAuraFrameIndex)
 			else
 				if (auraType == "HARMFUL") then
 					local color = DebuffTypeColor[debuffType] or DebuffTypeColor["none"];
-					aura.border:SetVertexColor(color.r,color.g,color.b);
-					aura.border:Show();
+					aura.border:SetBackdropBorderColor(unpack(cfg.auraBorderDebuffColor));
 				else
 					aura.border:Hide();
 				end

--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -33,6 +33,11 @@ end
 local modName = ...;
 local tt = CreateFrame("Frame",modName,UIParent,BackdropTemplateMixin and "BackdropTemplate");	-- 9.0.1: Using BackdropTemplate
 
+-- actual pixel perfect scale
+local ui_scale = UIParent:GetEffectiveScale()
+local height = select(2, GetPhysicalScreenSize())
+local ppScale = (768 / height) / ui_scale
+
 -- Global Chat Message Function
 function AzMsg(msg) DEFAULT_CHAT_FRAME:AddMessage(tostring(msg):gsub("|1","|cffffff80"):gsub("|2","|cffffffff"),0.5,0.75,1.0); end
 
@@ -561,9 +566,9 @@ end
 --                                              Settings                                              --
 --------------------------------------------------------------------------------------------------------
 
--- Get nearest pixel size (e.g. to avoid 1-pixel borders, which are sometimes 0/2-pixels wide)
+-- Get nearest pixel size (e.g. to avoid 1-pixel borders, which are sometimes 2-pixels wide)
 local function GetNearestPixelSize(size)
-	return PixelUtil.GetNearestPixelSize(size, cfg.gttScale);
+	return size * ppScale;
 end
 
 -- Resolves the given table array of string names into their global objects
@@ -905,8 +910,9 @@ end
 function tt:AnchorFrameToMouse(frame)
 	local x, y = GetCursorPosition();
 	local effScale = frame:GetEffectiveScale();
+	local offsetX, offsetY = cfg.mouseOffsetX * ppScale, cfg.mouseOffsetY * ppScale;
 	frame:ClearAllPoints();
-	frame:SetPoint(frame.ttAnchorPoint,UIParent,"BOTTOMLEFT",(x / effScale + cfg.mouseOffsetX),(y / effScale + cfg.mouseOffsetY));
+	frame:SetPoint(frame.ttAnchorPoint,UIParent,"BOTTOMLEFT",(x / effScale + offsetX),(y / effScale + offsetY));
 end
 
 -- Re-anchor for anchor type mouse

--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -146,6 +146,13 @@ local TT_DefaultConfig = {
 	auraMaxRows = 2,
 	showAuraCooldown = true,
 	noCooldownCount = false,
+	auraCustomBorder = true,
+	auraBorderUseParentColor = false,
+	auraBorderBuffColor = { 0, 1, 0 },
+	auraBorderDebuffColor = { 1, 0, 0 },
+	auraOffsetX = 2,
+	auraOffsetY = 2,
+	auraMinOffsetBetweenBuffAndDebuff = 10,
 
 	iconRaid = true,
 	iconFaction = false,
@@ -234,6 +241,7 @@ local TT_DefaultConfig = {
 	if_iconTooltipAnchor = "TOPLEFT",
 	if_iconOffsetX = 2.5,
 	if_iconOffsetY = -2.5,
+	if_copyParentBorder = false,
 };
 
 -- Tips modified by TipTac in appearance and scale, you can add to this list if you want to modify more tips.

--- a/TipTacOptions/ttOptions.lua
+++ b/TipTacOptions/ttOptions.lua
@@ -181,8 +181,21 @@ local options = {
 		{ type = "Check", var = "selfAurasOnly", label = "Only Show Auras Coming from You", tip = "This will filter out and only display auras you cast yourself", y = 12 },
 		{ type = "Slider", var = "auraSize", label = "Aura Icon Dimension", min = 8, max = 60, step = 1, y = 12 },
 		{ type = "Slider", var = "auraMaxRows", label = "Max Aura Rows", min = 1, max = 8, step = 1 },
+
+		{ type = "Slider", var = "auraOffsetX", label = "X offset between aura icons", min = 0, max = 20, step = 1 },
+		{ type = "Slider", var = "auraOffsetY", label = "Y offset between aura rows", min = 0, max = 20, step = 1 },
+		{ type = "Slider", var = "auraMinOffsetBetweenBuffAndDebuff", label = "Min. dist. between buffs/debuffs", min = 0, max = 50, step = 1 },
+
+
 		{ type = "Check", var = "showAuraCooldown", label = "Show Cooldown Models", tip = "With this option on, you will see a visual progress of the time left on the buff", y = 8 },
 		{ type = "Check", var = "noCooldownCount", label = "No Cooldown Count Text", tip = "Tells cooldown enhancement addons, such as OmniCC, not to display cooldown text" },
+	
+		{ type = "Check", var = "auraCustomBorder", label = "Custom aura icon border", tip = "Use a custom aura icon border" },
+		{ type = "Check", var = "auraBorderUseParentColor", label = "Copy border color of tooltip", tip = "Copies the bordercolor of the tooltip for the aura icons" },
+		{ type = "Color", var = "auraBorderBuffColor", label = "Custom buff border color" },
+		{ type = "Color", var = "auraBorderDebuffColor", label = "Custom debuff border color" },
+
+
 	},
 	-- Icon
 	{
@@ -317,6 +330,7 @@ if (TipTacItemRef) then
 		{ type = "Check", var = "if_showIcon", label = "Show Icon Texture and Stack Count (when available)", tip = "Shows an icon next to the tooltip. For items, the stack count will also be shown", y = 12 },
 		{ type = "Check", var = "if_smartIcons", label = "Smart Icon Appearance", tip = "When enabled, TipTacItemRef will determine if an icon is needed, based on where the tip is shown. It will not be shown on actionbars or bag slots for example, as they already show an icon" },
 		{ type = "Check", var = "if_borderlessIcons", label = "Borderless Icons", tip = "Turn off the border on icons" },
+		{ type = "Check", var = "if_copyParentBorder", label = "Copy border from tooltip", tip = "Copies the border from the tooltip" },
 		{ type = "Slider", var = "if_iconSize", label = "Icon Size", min = 16, max = 128, step = 1 },
 		{ type = "DropDown", var = "if_iconAnchor", label = "Icon Anchor", tip = "The anchor of the icon", list = DROPDOWN_ANCHORPOS },
 		{ type = "DropDown", var = "if_iconTooltipAnchor", label = "Icon Tooltip Anchor", tip = "The anchor of the tooltip that the icon should anchor to.", list = DROPDOWN_ANCHORPOS },


### PR DESCRIPTION
I implemented borders for the item icon and the aura icons. It just copies the borderstyle of the parent tooltip. Additionally I added various options for the auras: 

- X and Y offsets for the aura icons
- Minimum distance between buffs and debuffs
- border colors, either copy the border color of the parent tooltip, or set custom colors for buffs and debuffs
- current behaviour with only debuffs having a border is still available

The borders are pixel-perfect and align perfectly with the parent tooltip, no shuffling or jumping at all. Max aura count per row etc. also works.

This includes #47 if you want to merge both, otherwise I can rebase this later if this is not acceptable yet.

How my tooltips look now as an example (censored):
![example](https://i.imgur.com/PNzdyfb.png)