### PR TITLE
Update C_TradeSkillUI.GetRecipeReagentItemLink

### DIFF
--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -167,7 +167,7 @@ local TT_DefaultConfig = {
 	anchorFrameUnitPoint = "BOTTOMRIGHT",
 	anchorFrameTipType = "normal",
 	anchorFrameTipPoint = "BOTTOMRIGHT",
-	
+
 	enableAnchorOverrideCF = false,
 	anchorOverrideCFType = "normal",
 	anchorOverrideCFPoint = "BOTTOMRIGHT",
@@ -416,7 +416,7 @@ end
 -- Login [One-Time-Event] -- Initialize Level for difficulty coloring
 function tt:PLAYER_LOGIN(event)
 	self.playerLevel = UnitLevel("player");
-	
+
 	-- Cleanup
 	self:UnregisterEvent(event);
 	self[event] = nil;
@@ -430,29 +430,29 @@ end
 -- Chain config tables
 local function ChainConfigTables(config, defaults)
 	local config_metatable_org = getmetatable(config);
-	
+
 	return setmetatable(config, {
 		__index = function(tab, index)
 			local value = defaults[index];
-			
+
 			if (value) then
 				return value;
 			end
-			
+
 			if (not config_metatable_org) then
 				return nil;
 			end
-			
+
 			local config_metatable_org__index = config_metatable_org.__index;
-			
+
 			if (not config_metatable_org__index) then
 				return nil;
 			end
-			
+
 			if (type(config_metatable_org__index) == "table") then
 				return config_metatable_org__index[index];
 			end
-			
+
 			return config_metatable_org__index(tab, index);
 		end
 	});
@@ -507,10 +507,10 @@ function tt:VARIABLES_LOADED(event)
 	if (not targetedByList) then
 		targetedByList = self:CreatePushArray();
 	end
-	
+
 	-- Re-Trigger event ADDON_LOADED for TipTac if config wasn't ready
 	self:ADDON_LOADED("ADDON_LOADED", "TipTac");
-	
+
 	-- Cleanup
 	self:UnregisterEvent(event);
 	self[event] = nil;
@@ -602,7 +602,7 @@ local function ResolveGlobalNamedObjects(tipTable)
 		-- lookup the global object from this name, assign false if nonexistent, to preserve the table entry
 		if (type(tipName) == "string") then
 			local tip = (_G[tipName] or false);
-			
+
 			-- Check if this object has already been resolved. This can happen for thing like AtlasLoot, which sets AtlasLootTooltip = GameTooltip
 			if (resolved[tip]) then
 				tip = false;
@@ -651,21 +651,21 @@ end
 -- Set scale to frame
 local function SetScale(frame)
 	local frameName = frame:GetName();
-	
+
 	-- don't scale some frames
 	if (frameName) and ((frameName == "QueueStatusFrame") or (frameName:match("DropDownList(%d+)")) or (frameName == "RaiderIO_ProfileTooltip") or (frameName == "RaiderIO_SearchTooltip")) then
 		return;
 	end
-	
+
 	frame:SetScale(cfg.gttScale);
 end
 
 -- Apply Settings
 function tt:ApplySettings()
 	updatePixelPerfectScale();
-	
+
 	if (not cfg) then return end;
-	
+
 	-- Hide World Tips Instantly
 	if (cfg.hideWorldTips) then
 		self:RegisterEvent(isWoWClassic and "CURSOR_UPDATE" or "CURSOR_CHANGED");
@@ -684,19 +684,19 @@ function tt:ApplySettings()
 	else
 		tipBackdrop.edgeFile = cfg.tipBackdropEdge;
 	end
-	
+
 	tipBackdrop.tile = false;
 	tipBackdrop.tileEdge = false;
-	
+
 	local edgeSize = ((cfg.pixelPerfectBackdrop and tt:GetNearestPixelSize(cfg.backdropEdgeSize, true)) or cfg.backdropEdgeSize);
 	tipBackdrop.edgeSize = edgeSize;
-	
+
 	local insets = ((cfg.pixelPerfectBackdrop and tt:GetNearestPixelSize(cfg.backdropInsets, true)) or cfg.backdropInsets);
 	tipBackdrop.insets.left = insets;
 	tipBackdrop.insets.right = insets;
 	tipBackdrop.insets.top = insets;
 	tipBackdrop.insets.bottom = insets;
-	
+
 	tipBackdrop.backdropColor:SetRGBA(unpack(cfg.tipColor));
 	tipBackdrop.backdropBorderColor:SetRGBA(unpack(cfg.tipBorderColor));
 
@@ -763,11 +763,11 @@ function tt:SetBackdropColorLocked(tip, lockColor, r, g, b, a)
 	if (not lockColor) and (tip.ttBackdropColorApplied) then
 		return;
 	end
-	
+
 	tip.ttSetBackdropColorLocked = false;
 	tip:SetBackdropColor(r, g, b, (a or 1) * (tipBackdrop.backdropColor.a or 1));
 	tip.ttSetBackdropColorLocked = true;
-	
+
 	if (lockColor) then
 		tip.ttBackdropColorApplied = true;
 	end
@@ -778,11 +778,11 @@ function tt:SetBackdropBorderColorLocked(tip, lockColor, r, g, b, a)
 	if (not lockColor) and (tip.ttBackdropBorderColorApplied) then
 		return;
 	end
-	
+
 	tip.ttSetBackdropBorderColorLocked = false;
 	tip:SetBackdropBorderColor(r, g, b, (a or 1) * (tipBackdrop.backdropBorderColor.a or 1));
 	tip.ttSetBackdropBorderColorLocked = true;
-	
+
 	if (lockColor) then
 		tip.ttBackdropBorderColorApplied = true;
 	end
@@ -803,11 +803,11 @@ function tt:SetPadding(tip, calledFromEvent)
 		return;
 	end
 	local oldPaddingWidth, oldPaddingHeight = tip:GetPadding();
-	
+
 	local itemTooltip = tip.ItemTooltip;
 	local isItemTooltipShown = (itemTooltip and itemTooltip:IsShown());
 	local isBottomFontStringShown = (tip.BottomFontString and tip.BottomFontString:IsShown());
-	
+
 	if (not isItemTooltipShown) and (not isBottomFontStringShown) and
 			(calledFromEvent ~= "GameTooltip_AddQuestRewardsToTooltip") and
 			(calledFromEvent ~= "GameTooltip_CalculatePadding") then
@@ -817,14 +817,14 @@ function tt:SetPadding(tip, calledFromEvent)
 		end
 		return;
 	end
-	
+
 	-- consider GameTooltip_AddQuestRewardsToTooltip() + GameTooltip_CalculatePadding()
 	-- commented out for embedded tooltips: SetPadding() makes problems with embedded tooltips.
-	
+
 	-- if (calledFromEvent == "OnTooltipCleared") then -- no SetPadding() here for embedded tooltips during event OnTooltipCleared
 		-- return;
 	-- end
-	
+
 	-- if (itemTooltip) then
 		-- if (isBottomFontStringShown) then
 			-- itemTooltip:SetPoint("BOTTOMLEFT", tip.BottomFontString, "TOPLEFT", 0, 10);
@@ -832,21 +832,21 @@ function tt:SetPadding(tip, calledFromEvent)
 			-- itemTooltip:SetPoint("BOTTOMLEFT", 10 + tt.padding.left, 13 + tt.padding.bottom);
 		-- end
 	-- end
-	
+
 	-- if (not tip:IsShown()) and (calledFromEvent ~= "GameTooltip_AddQuestRewardsToTooltip") then
 		-- return;
 	-- end
 
 	-- local newPaddingRight, newPaddingBottom, newPaddingLeft, newPaddingTop = tt.padding.right, tt.padding.bottom, tt.padding.left, tt.padding.top;
-	
+
 	-- newPaddingRight = oldPaddingWidth + tt.padding.right;print(newPaddingRight, tip:IsShown(), calledFromEvent);
-	
+
 	-- if (calledFromEvent == "GameTooltip_AddQuestRewardsToTooltip") then
 		-- newPaddingBottom = oldPaddingHeight + tt.padding.bottom;
 	-- else
 		-- newPaddingBottom = oldPaddingHeight;
 	-- end
-	
+
 	-- if (math.abs(newPaddingRight - oldPaddingWidth) > 0.5) or (math.abs(newPaddingBottom - oldPaddingHeight) > 0.5) then
 		-- tip:SetPadding(newPaddingRight, newPaddingBottom, tt.padding.left, tt.padding.top);
 	-- end
@@ -879,7 +879,7 @@ function tt:ApplyTipBackdrop(tip, calledFromEvent, resetBackdropColor)
 	if (not cfg.enableBackdrop) then
 		return;
 	end
-	
+
 	-- remove default tip backdrop
 	if (tip.NineSlice) then
 		StripTextures(tip.NineSlice);
@@ -888,40 +888,40 @@ function tt:ApplyTipBackdrop(tip, calledFromEvent, resetBackdropColor)
 		tip.NineSlice.layoutTextureKit = nil;
 		tip.NineSlice.backdropInfo = nil;
 	end
-	
+
 	tip.layoutType = nil;
 	tip.layoutTextureKit = nil;
 	tip.backdropInfo = nil;
-	
+
 	local tipName = tip:GetName();
-	
+
 	if (tipName) and (tipName:match("DropDownList(%d+)")) then
 		local dropDownListBackdrop = _G[tipName.."Backdrop"];
 		local dropDownListMenuBackdrop = _G[tipName.."MenuBackdrop"];
-		
+
 		StripTextures(dropDownListBackdrop);
 		if (dropDownListBackdrop.Bg) then
 			dropDownListBackdrop.Bg:SetTexture(nil);
 		end
 		StripTextures(dropDownListMenuBackdrop.NineSlice);
-		
+
 		if (IsAddOnLoaded("ElvUI")) then -- workaround for addon ElvUI to prevent applying of frame:StripTextures()
 			tip.template = "Default";
 			dropDownListBackdrop.template = "Default";
 			dropDownListMenuBackdrop.template = "Default";
 		end
 	end
-	
+
 	-- apply tip backdrop
 	tt:SetBackdropLocked(tip, tipBackdrop);
-	
+
 	if (resetBackdropColor) then
 		tt:ResetBackdropBorderColorLocked(tip);
 	else
 		tt:SetBackdropColorLocked(tip, false, tipBackdrop.backdropColor:GetRGBA());
 		tt:SetBackdropBorderColorLocked(tip, false, tipBackdrop.backdropBorderColor:GetRGBA());
 	end
-	
+
 	-- apply padding
 	tt:SetPadding(tip, calledFromEvent);
 end
@@ -930,33 +930,33 @@ end
 local function IsInFrameChain(frame, patternsOrFrame, maxLevel)
 	local currentFrame = frame;
 	local currentLevel = 1;
-	
+
 	while (currentFrame) do
 		if (type(currentFrame.GetName) ~= "function") then
 			return false;
 		end
-		
+
 		local currentFrameName = currentFrame:GetName();
-		
+
 		for _, patternOrFrame in ipairs(patternsOrFrame) do
 			if (patternOrFrame) then
 				local typePatternOrFrame = type(patternOrFrame);
-				
+
 				if ((typePatternOrFrame == "string") and (currentFrameName) and (currentFrameName:match(patternOrFrame))) or
 						((typePatternOrFrame == "table") and (currentFrame == patternOrFrame)) then
 					return true;
 				end
 			end
 		end
-		
+
 		if (maxLevel) and (currentLevel == maxLevel) then
 			return false;
 		end
-		
+
 		currentFrame = currentFrame:GetParent();
 		currentLevel = currentLevel + 1;
 	end
-	
+
 	return false;
 end
 
@@ -969,9 +969,9 @@ local function GetAnchorPosition(tooltip)
 	local mouseFocus = GetMouseFocus();
 	local isUnit = (tooltip.ttDisplayingUnit) or (not tooltip.ttDisplayingAura) and (UnitExists("mouseover") or (mouseFocus and mouseFocus.GetAttribute and mouseFocus:GetAttribute("unit")));	-- Az: GetAttribute("unit") here is bad, as that will find things like buff frames too
 	local var = "anchor"..(mouseFocus == WorldFrame and "World" or "Frame")..(isUnit and "Unit" or "Tip");
-	
+
 	local ttAnchorType, ttAnchorPoint = cfg[var.."Type"], cfg[var.."Point"];
-	
+
 	-- check for anchor overrides
 	if (tooltip == gtt) then
 		 -- don't anchor GTT (frame tip type) in "Premade Groups->LFGList" to mouse if addon RaiderIO is loaded
@@ -981,14 +981,14 @@ local function GetAnchorPosition(tooltip)
 				}, 4)) then
 			return "normal", "BOTTOMRIGHT";
 		end
-		
+
 		-- workaround for bug in RaiderIO: https://github.com/RaiderIO/raiderio-addon/issues/203
 		if (var == "anchorFrameTip") and (ttAnchorType == "mouse") and (IsAddOnLoaded("RaiderIO")) and IsAddOnLoaded("Blizzard_Communities") and (IsInFrameChain(tooltip:GetOwner(), {
 					CommunitiesFrame.MemberList.ListScrollFrame
 				}, 3)) then
 			return "normal", "BOTTOMRIGHT";
 		end
-		
+
 		-- override GTT anchor for (Guild & Community) ChatFrame
 		if (cfg.enableAnchorOverrideCF) and (IsInFrameChain(tooltip:GetOwner(), {
 					"ChatFrame(%d+)",
@@ -997,7 +997,7 @@ local function GetAnchorPosition(tooltip)
 			return cfg.anchorOverrideCFType, cfg.anchorOverrideCFPoint;
 		end
 	end
-	
+
 	return ttAnchorType, ttAnchorPoint;
 end
 
@@ -1057,7 +1057,7 @@ function tt:ReApplyAnchorTypeForMouse(frame, noUpdateAnchorPosition, ignoreWorld
 	if (not noUpdateAnchorPosition) then
 		frame.ttAnchorType, frame.ttAnchorPoint = GetAnchorPosition(frame);
 	end
-	
+
 	if (frame.ttAnchorType == "mouse") and (frame:GetObjectType() == "GameTooltip") and (not TT_NoReApplyAnchorFor[frame:GetName()]) then
 		local gttAnchor = frame:GetAnchorType();
 		if (ignoreWorldTips) and ((gttAnchor == "ANCHOR_CURSOR") or (gttAnchor == "ANCHOR_CURSOR_RIGHT")) then
@@ -1131,7 +1131,7 @@ end
 -- Add "Targeted By" line
 function tt:AddTargetedBy(u)
 	local numUnits, inGroup, inRaid, nameplates;
-	
+
 	local numGroup = GetNumGroupMembers();
 	if (numGroup) and (numGroup >= 1) then
 		numUnits = numGroup;
@@ -1142,10 +1142,10 @@ function tt:AddTargetedBy(u)
 		numUnits = #nameplates;
 		inGroup = false;
 	end
-	
+
 	for i = 1, numUnits do
 		local unit = inGroup and (inRaid and "raid"..i or "party"..i) or (nameplates[i].namePlateUnitToken);
-		if (UnitIsUnit(unit.."target", u.token)) and (not UnitIsUnit(unit, "player")) then
+		if unit and (UnitIsUnit(unit.."target", u.token)) and (not UnitIsUnit(unit, "player")) then
 			local _, classFile = UnitClass(unit);
 			targetedByList.next = TT_ClassColorMarkup[classFile];
 			targetedByList.next = UnitName(unit);
@@ -1219,7 +1219,7 @@ function tt:ApplyUnitAppearance(tip,first)
 	-- [3] Send style event AFTER tip has been styled
 	self:SendElementEvent("OnPostStyleTip",tip,first);
 	--------------------------------------------------
-	
+
 	-- reapply tooltip padding. padding might have been modified to fit health/power bars.
 	tt:SetPadding(tip);
 end
@@ -1246,12 +1246,12 @@ end
 local function IRTT_DisplayDungeonScoreLink(link)
 	if (cfg.classColoredBorder) and (irtt:IsShown()) then
 		local splits = StringSplitIntoTable(":", link);
-		
+
 		--Bad Link, Return.
 		if (not splits) then
 			return;
 		end
-		
+
 		local playerClass = splits[5];
 		local className, classFileName = GetClassInfo(playerClass);
 		local classColor = C_ClassColor.GetClassColor(classFileName);
@@ -1265,9 +1265,9 @@ local function LFGLFAVSFBM_OnEnter_Hook(self)
 	if (cfg.classColoredBorder) and (gtt:IsShown()) then
 		local applicantID = self:GetParent().applicantID;
 		local memberIdx = self.memberIdx;
-		
+
 		local name, class, localizedClass, level, itemLevel, honorLevel, tank, healer, damage, assignedRole, relationship, dungeonScore, pvpItemLevel = C_LFGList.GetApplicantMemberInfo(applicantID, memberIdx);
-		
+
 		if (name) then
 			local classColor = RAID_CLASS_COLORS[class];
 			tt:SetBackdropBorderColorLocked(gtt, true, classColor.r, classColor.g, classColor.b);
@@ -1326,7 +1326,7 @@ function gttScriptHooks:OnUpdate(elapsed)
 	-- else
 	-- Anchor GTT to Mouse (no anchoring e.g. for tooltips from AddModifiedTip() or compare items)
 	tt:ReApplyAnchorTypeForMouse(self, true, true);
-	
+
 	-- WoD: This background color reset, from OnShow(), has been copied down here. It seems resetting the color in OnShow() wasn't enough, as the color changes after the tip is being shown
 	-- if (self:IsOwned(UIParent)) and (not self:GetUnit()) then
 		-- tt:SetBackdropColorLocked(self, false, unpack(cfg.tipColor));
@@ -1366,9 +1366,9 @@ function gttScriptHooks:OnTooltipSetUnit()
 		self:Hide();
 		return;
 	end
-	
+
 	self.ttUnit = {};
-	
+
 	local _, unit = self:GetUnit();
 
 	-- Concated unit tokens such as "targettarget" cannot be returned as the unit by GTT:GetUnit(),
@@ -1464,7 +1464,7 @@ local function GTT_SetDefaultAnchor(tooltip,parent)
 	if (not tooltip or not parent) then
 		return;
 	end
-	
+
 	SetDefaultAnchor(tooltip, parent);
 
 	-- "ttDefaultAnchored" will flag the tooltip as having been anchored using the default anchor
@@ -1502,7 +1502,7 @@ end
 local function GTT_SetUnit(self)
 	-- "ttDisplayingUnit" will flag the tooltip that it is currently showing a unit
 	self.ttDisplayingUnit = true;
-	
+
 	SetDefaultAnchor(self, self:GetOwner(), true);
 end
 
@@ -1545,7 +1545,7 @@ end
 --[[
 	BattlePetTooltip / EncounterJournalTooltip Construction Call Order
 	------------------------------------------------------------------
-	- GameTooltip_SetDefaultAnchor()        -- 
+	- GameTooltip_SetDefaultAnchor()        --
 	- BPTT/EJTT:Show()					    -- Will Resize the tip
 	- BPTT/EJTT.OnShow()					-- Event triggered in response to the Show() function
 	- BPTT/EJTT.OnHide()		           	-- Tooltip has been hidden
@@ -1627,12 +1627,12 @@ function tt:AddLockingFeature(tip)
 	if (not cfg.enableBackdrop) then
 		return;
 	end
-	
+
 	local tip_ApplyBackdrop_org = tip.ApplyBackdrop;
 	local tip_SetBackdrop_org = tip.SetBackdrop;
 	local tip_SetBackdropColor_org = tip.SetBackdropColor;
 	local tip_SetBackdropBorderColor_org = tip.SetBackdropBorderColor;
-	
+
 	tip.ApplyBackdrop = function(self, ...)
 		if (self.ttSetBackdropLocked) then
 			return;
@@ -1665,7 +1665,7 @@ function tt:AddLockingFeature(tip)
 			tip_SetBackdropBorderColor_org(self, ...);
 		end
 	end
-	
+
 	if (tip.NineSlice) then
 		local tip_NineSlice_ApplyBackdrop_org = tip.NineSlice.ApplyBackdrop;
 		local tip_NineSlice_SetBackdrop_org = tip.NineSlice.SetBackdrop;
@@ -1673,7 +1673,7 @@ function tt:AddLockingFeature(tip)
 		local tip_NineSlice_SetBackdropBorderColor_org = tip.NineSlice.SetBackdropBorderColor;
 		local tip_NineSlice_SetCenterColor_org = tip.NineSlice.SetCenterColor;
 		local tip_NineSlice_SetBorderColor_org = tip.NineSlice.SetBorderColor;
-		
+
 		tip.NineSlice.ApplyBackdrop = function(self, ...)
 			if (self:GetParent().ttSetBackdropLocked) then
 				return;
@@ -1737,11 +1737,11 @@ function tt:ApplyHooksToTips(tips, resolveGlobalNamedObjects, addToTipsToModify)
 		if (type(tip) == "table") and (type(tip.GetObjectType) == "function") then
 			local tipName = tip:GetName();
 			local tipHooked = false;
-			
+
 			if (addToTipsToModify) then
 				TT_TipsToModify[#TT_TipsToModify + 1] = tip;
 			end
-			
+
 			if (tip:GetObjectType() == "GameTooltip") then
 				for scriptName, hookFunc in next, gttScriptHooks do
 					tip:HookScript(scriptName, hookFunc);
@@ -1754,52 +1754,52 @@ function tt:ApplyHooksToTips(tips, resolveGlobalNamedObjects, addToTipsToModify)
 				hooksecurefunc(tip, "SetUnitAura", GTT_SetUnitAura);
 				hooksecurefunc(tip, "SetUnitBuff", GTT_SetUnitAura);
 				hooksecurefunc(tip, "SetUnitDebuff", GTT_SetUnitAura);
-				
+
 				if (isWoWSl) or (isWoWRetail) then
 					-- Post-Hook GameTooltip:SetToyByItemID() to prevent flickering of tooltips if scrolling over toys from last page to previous page and "Anchors->Frame Tip Type" = "Mouse Anchor"
 					hooksecurefunc(tip, "SetToyByItemID", GTT_SetToyByItemID);
 				end
-				
+
 				if (tipName == "GameTooltip") then
 					-- Replace GameTooltip_SetDefaultAnchor() (For Re-Anchoring) -- Patch 3.2 made this function secure
 					hooksecurefunc("GameTooltip_SetDefaultAnchor", GTT_SetDefaultAnchor);
-					
+
 					-- Post-Hook SharedTooltip_SetBackdropStyle() to reapply backdrop (e.g. needed for OnTooltipSetItem() or AreaPOIPinMixin:OnMouseEnter() on world map (e.g. Torghast) or VignettePin on world map (e.g. weekly event in Maw))
 					hooksecurefunc("SharedTooltip_SetBackdropStyle", STT_SetBackdropStyle);
-					
+
 					-- Post-Hook QuestPinMixin:OnMouseEnter() to re-anchor tooltip (e.g. quests on world map with numeric banner) if "Anchors->Frame Tip Type" = "Mouse Anchor"
 					hooksecurefunc(QuestPinMixin, "OnMouseEnter", QPM_OnMouseEnter);
-					
+
 					-- Post-Hook TaskPOI_OnEnter() to reapply padding if modified
 					-- commented out for embedded tooltips, see description in tt:SetPadding()
 					-- hooksecurefunc("TaskPOI_OnEnter", function(self)
 					  -- tt:SetPadding(gtt, "GameTooltip_AddQuestRewardsToTooltip");
 					-- end);
-					
+
 					-- Post-Hook GameTooltip_AddQuestRewardsToTooltip() to reapply padding if modified
 					-- commented out for embedded tooltips, see description in tt:SetPadding()
 					-- hooksecurefunc("GameTooltip_AddQuestRewardsToTooltip", GTT_AddQuestRewardsToTooltip);
-					
+
 					-- Post-Hook GameTooltip_CalculatePadding() to reapply padding if modified
 					-- commented out for embedded tooltips, see description in tt:SetPadding()
 					-- hooksecurefunc("GameTooltip_CalculatePadding", GTT_CalculatePadding);
-					
+
 					if (isWoWSl) or (isWoWRetail) then
 						-- Post-Hook QuestUtils_AddQuestRewardsToTooltip() to reset padding to fix displaying of embedded tooltips
 						-- added helper function for embedded tooltips, see description in tt:SetPadding()
 						hooksecurefunc("QuestUtils_AddQuestRewardsToTooltip", QU_AddQuestRewardsToTooltip);
-						
+
 						-- Post-Hook RuneforgePowerBaseMixin:OnEnter() to re-anchor tooltip in adventure journal if "Anchors->Frame Tip Type" = "Mouse Anchor" and scrolling up and down, see WardrobeItemsCollectionMixin:UpdateItems() in "Blizzard_Collections/Blizzard_Wardrobe.lua"
 						hooksecurefunc(RuneforgePowerBaseMixin, "OnEnter", RPBM_OnEnter_Hook);
 
 						-- Function to apply necessary hooks to LFGListFrame.ApplicationViewer.ScrollFrame.buttons to apply class colors
 						if (isWoWSl) then -- df todo: ScrollFrame doesn't exist in df. replaced with ScrollBox.
 							tt:ApplyHooksToLFGLFAVSFB();
-							
+
 							hooksecurefunc("LFGListApplicationViewer_UpdateApplicant", function(button, applicantID)
 								tt:ApplyHooksToLFGLFAVSFB(button, applicantID);
 							end);
-							
+
 							hooksecurefunc("LFGListApplicantMember_OnEnter", LFGLFAVSFBM_OnEnter_Hook);
 						end
 					end
@@ -1838,7 +1838,7 @@ function tt:ApplyHooksToTips(tips, resolveGlobalNamedObjects, addToTipsToModify)
 					tipHooked = true;
 				end
 			end
-			
+
 			if (tipHooked) then
 				tt:AddLockingFeature(tip);
 			end
@@ -1892,7 +1892,7 @@ function tt:HookTips()
 	-- Hooks needs to be applied as late as possible during load, as we want to try and be the
 	-- last addon to hook "OnTooltipSetUnit" so we always have a "completed" tip to work on
 	self:ApplyHooksToTips(TT_TipsToModify, true);
-	
+
 	-- hook their OnHide script -- Az: OnHide hook disabled for now
 --	for index, tipName in ipairs(TT_TipsToModify) do
 --		if (type(tip) == "table") and (type(tip.GetObjectType) == "function") then
@@ -1907,12 +1907,12 @@ end
 -- AddOn Loaded
 function tt:ADDON_LOADED(event, addOnName)
 	if (not cfg) then return end;
-	
+
 	-- check if addon is already loaded
 	if (TT_AddOnsLoaded[addOnName] == nil) or (TT_AddOnsLoaded[addOnName]) then
 		return;
 	end
-	
+
 	-- now LibQTip might be available
 	if (addOnName == "TipTac") then
 		if (LibQTip) then
@@ -1928,7 +1928,7 @@ function tt:ADDON_LOADED(event, addOnName)
 	if (addOnName == "Blizzard_Collections") or ((addOnName == "TipTac") and (IsAddOnLoaded("Blizzard_Collections")) and (not TT_AddOnsLoaded['Blizzard_Collections'])) then
 		pjpatt = PetJournalPrimaryAbilityTooltip;
 		pjsatt = PetJournalSecondaryAbilityTooltip;
-		
+
 		-- Hook Tips & Apply Settings
 		self:ApplyHooksToTips({
 			"PetJournalPrimaryAbilityTooltip",
@@ -1939,7 +1939,7 @@ function tt:ADDON_LOADED(event, addOnName)
 
 		-- Post-Hook WardrobeCollectionFrame.ItemsCollectionFrame:UpdateItems() to re-anchor tooltip at transmogrifier if "Anchors->Frame Tip Type" = "Mouse Anchor" and selecting items, see WardrobeItemsCollectionMixin:UpdateItems() in "Blizzard_Collections/Blizzard_Wardrobe.lua"
 		hooksecurefunc(WardrobeCollectionFrame.ItemsCollectionFrame, "UpdateItems", WCFICF_UpdateItems_Hook);
-		
+
 		if (addOnName == "TipTac") then
 			TT_AddOnsLoaded["Blizzard_Collections"] = true;
 		end
@@ -1949,12 +1949,12 @@ function tt:ADDON_LOADED(event, addOnName)
 		if (isWoWSl) then -- df todo: ListScrollFrame doesn't exist in df. replaced with ScrollBox.
 		-- Function to apply necessary hooks to CommunitiesFrame.MemberList.ListScrollFrame to apply class colors
 			tt:ApplyHooksToCFMLLSF();
-			
+
 			hooksecurefunc(CommunitiesFrame.MemberList, "RefreshLayout", function()
 				tt:ApplyHooksToCFMLLSF();
 			end);
 		end
-		
+
 		if (addOnName == "TipTac") then
 			TT_AddOnsLoaded["Blizzard_Communities"] = true;
 		end
@@ -1967,7 +1967,7 @@ function tt:ADDON_LOADED(event, addOnName)
 		}, true, true);
 
 		self:ApplySettings();
-		
+
 		if (addOnName == "TipTac") then
 			TT_AddOnsLoaded["Blizzard_Contribution"] = true;
 		end
@@ -1975,7 +1975,7 @@ function tt:ADDON_LOADED(event, addOnName)
 	-- now EncounterJournalTooltip exists
 	if (addOnName == "Blizzard_EncounterJournal") or ((addOnName == "TipTac") and (IsAddOnLoaded("Blizzard_EncounterJournal")) and (not TT_AddOnsLoaded['Blizzard_EncounterJournal'])) then
 		ejtt = EncounterJournalTooltip;
-		
+
 		-- Hook Tips & Apply Settings
 		-- commented out for embedded tooltips, see description in tt:SetPadding()
 		-- self:ApplyHooksToTips({
@@ -1983,7 +1983,7 @@ function tt:ADDON_LOADED(event, addOnName)
 		-- }, true, true);
 
 		-- self:ApplySettings();
-		
+
 		if (addOnName == "TipTac") then
 			TT_AddOnsLoaded["Blizzard_EncounterJournal"] = true;
 		end
@@ -1996,27 +1996,27 @@ function tt:ADDON_LOADED(event, addOnName)
 				"RaiderIO_ProfileTooltip",
 				"RaiderIO_SearchTooltip"
 			}, true, true);
-			
+
 			self:ApplySettings();
 		end);
-		
+
 		if (addOnName == "TipTac") then
 			TT_AddOnsLoaded["RaiderIO"] = true;
 		end
 	end
-	
+
 	TT_AddOnsLoaded[addOnName] = true;
-	
+
 	-- Cleanup if all addons are loaded
 	local allAddOnsLoaded = true;
-	
+
 	for addOn, isLoaded in pairs(TT_AddOnsLoaded) do
 		if (not isLoaded) then
 			allAddOnsLoaded = false;
 			break;
 		end
 	end
-	
+
 	if (allAddOnsLoaded) then
 		self:UnregisterEvent(event);
 		self[event] = nil;
@@ -2045,7 +2045,7 @@ function tt:AddModifiedTip(tip,noHooks)
 --		if (not noHooks) then
 --			tip:HookScript("OnHide",gttScriptHooks.OnHide);
 --		end
-		
+
 		if (not noHooks) then
 			tip:HookScript("OnShow", function()
 				tt:ApplyTipBackdrop(tip);

--- a/TipTacItemRef/ttItemRef.lua
+++ b/TipTacItemRef/ttItemRef.lua
@@ -253,29 +253,29 @@ end
 -- Chain config tables
 local function ChainConfigTables(config, defaults)
 	local config_metatable_org = getmetatable(config);
-	
+
 	return setmetatable(config, {
 		__index = function(tab, index)
 			local value = defaults[index];
-			
+
 			if (value) then
 				return value;
 			end
-			
+
 			if (not config_metatable_org) then
 				return nil;
 			end
-			
+
 			local config_metatable_org__index = config_metatable_org.__index;
-			
+
 			if (not config_metatable_org__index) then
 				return nil;
 			end
-			
+
 			if (type(config_metatable_org__index) == "table") then
 				return config_metatable_org__index[index];
 			end
-			
+
 			return config_metatable_org__index(tab, index);
 		end
 	});
@@ -298,10 +298,10 @@ function ttif:VARIABLES_LOADED(event)
 	-- Hook Tips & Apply Settings
 	self:HookTips();
 	self:OnApplyConfig();
-	
+
 	-- Re-Trigger event ADDON_LOADED for TipTacItemRef if config wasn't ready
 	self:ADDON_LOADED("ADDON_LOADED", "TipTacItemRef");
-	
+
 	-- Cleanup
 	self:UnregisterEvent(event);
 	self[event] = nil;
@@ -347,7 +347,7 @@ end
 -- 3   = no hooks set respectively not needed any more
 function ttif:ApplyWorkaroundForFirstMouseover(self, isAura, source, link, linkType, id, rank)
 	local tooltip = self;
-	
+
 	-- functions
 	local reapplyTooltipModificationFn = function()
 		tipDataAdded[tooltip] = linkType;
@@ -361,7 +361,7 @@ function ttif:ApplyWorkaroundForFirstMouseover(self, isAura, source, link, linkT
 		AceHook:Unhook(tooltip, "OnUpdate");
 		tooltip.ttWorkaroundForFirstMouseoverStatus = 3;
 	end
-	
+
 	local removeHooksFn = function(resetVars)
 		if (tooltip.ttWorkaroundForFirstMouseoverStatus == 1) then
 			AceHook:Unhook(tooltip, "OnTooltipCleared");
@@ -372,7 +372,7 @@ function ttif:ApplyWorkaroundForFirstMouseover(self, isAura, source, link, linkT
 		elseif (tooltip.ttWorkaroundForFirstMouseoverStatus == 3) then
 			AceHook:Unhook(tooltip, "OnHide");
 		end
-		
+
 		if (resetVars) then
 			tooltip.ttWorkaroundForFirstMouseoverStatus = nil;
 			tooltip.ttWorkaroundForFirstMouseoverID = nil;
@@ -380,14 +380,14 @@ function ttif:ApplyWorkaroundForFirstMouseover(self, isAura, source, link, linkT
 			tooltip.ttWorkaroundForFirstMouseoverOwner = nil;
 		end
 	end
-	
+
 	-- remove previous hooks if different id
 	local owner = tooltip:GetOwner();
-	
+
 	if (tooltip.ttWorkaroundForFirstMouseoverStatus) and ((tooltip.ttWorkaroundForFirstMouseoverID ~= id) or (owner ~= tooltip.ttWorkaroundForFirstMouseoverOwner)) then
 		removeHooksFn(true);
 	end
-	
+
 	-- apply hooks
 	if (not tooltip.ttWorkaroundForFirstMouseoverStatus) then
 		AceHook:SecureHookScript(tooltip, "OnTooltipCleared", function()
@@ -421,11 +421,11 @@ local function PJATT_EJTT_AddTextLine(self, text, r, g, b, wrap)
 	local anchorXOfs = 0;
 	local anchorYOfs = 0;
 	local anchorXOfsWrap = 0;
-	
+
 	if not r then
 		r, g, b = NORMAL_FONT_COLOR:GetRGB();
 	end
-	
+
 	local anchor = self.textLineAnchor;
 	if not anchor then
 		if (self == pjpatt or self == pjsatt or self == fpbatt) then
@@ -442,22 +442,22 @@ local function PJATT_EJTT_AddTextLine(self, text, r, g, b, wrap)
 			anchorYOfs = 6;
 		end
 	end
-	
+
 	local line = self.linePool:Acquire();
 	line:SetText(text);
 	line:SetTextColor(r, g, b);
 	line:SetPoint("TOPLEFT", anchor, "BOTTOMLEFT", anchorXOfs, -linePadding + anchorYOfs);
-	
+
 	if wrap then
 		line:SetPoint("RIGHT", self, "RIGHT", anchorXOfsWrap, -linePadding + anchorYOfs);
 	end
-	
+
 	line:Show();
-	
+
 	self.textLineAnchor = line;
-	
+
 	self:SetHeight(self:GetHeight() + line:GetHeight() + linePadding);
-	
+
 	if (self == pjpatt or self == pjsatt or self == fpbatt) then
 		self.bottomFrame = line;
 	end
@@ -478,7 +478,7 @@ end
 
 --
 -- main hooking functions
--- 
+--
 
 -- HOOK: ItemRefTooltip + GameTooltip:SetHyperlink
 function ttif:SetHyperlink_Hook(self, hyperlink)
@@ -551,7 +551,7 @@ local function SetAction_Hook(self, slot)
 			local name = line and (line:GetText() or "");
 			if (name ~= "" and PetHasSpellbook()) then
 				local numPetSpells, petToken = HasPetSpells(); -- returns numPetSpells = nil for feral spirit (shaman wolves) in wotlkc
-				
+
 				if (numPetSpells) then
 					for i = 1, numPetSpells do
 						local spellType, _id = GetSpellBookItemInfo(i, BOOKTYPE_PET); -- see SpellButton_OnEnter() in "SpellBookFrame.lua"
@@ -567,7 +567,7 @@ local function SetAction_Hook(self, slot)
 					end
 				end
 			end
-			
+
 			if (not tipDataAdded[self]) then -- fallback if pet action was not found in pet spell book by name.
 				local icon = GetActionTexture(slot);
 				tipDataAdded[self] = "petAction";
@@ -580,11 +580,11 @@ local function SetAction_Hook(self, slot)
 				if (itemID) then
 					tipDataAdded[self] = linkType;
 					LinkTypeFuncs.item(self, link, linkType, itemID);
-					
+
 					-- apply workaround for first mouseover if item is a toy
 					if (C_ToyBox) then
 						_itemID, toyName, icon, isFavorite, hasFanfare, itemQuality = C_ToyBox.GetToyInfo(itemID);
-						
+
 						if (_itemID) then
 							ttif:ApplyWorkaroundForFirstMouseover(self, false, nil, link, linkType, itemID);
 						end
@@ -656,10 +656,10 @@ local function SetPetAction_Hook(self, slot)
 				_name = name;
 				icon = texture;
 			end
-			
+
 			if (_name ~= "" and PetHasSpellbook()) then -- id is missing. as a workaround find pet action in pet spell book by name.
 				local numPetSpells, petToken = HasPetSpells(); -- returns numPetSpells = nil for feral spirit (shaman wolves) in wotlkc
-				
+
 				if (numPetSpells) then
 					for i = 1, numPetSpells do
 						local spellType, id = GetSpellBookItemInfo(i, BOOKTYPE_PET); -- see SpellButton_OnEnter() in "SpellBookFrame.lua"
@@ -674,7 +674,7 @@ local function SetPetAction_Hook(self, slot)
 					end
 				end
 			end
-			
+
 			if (not tipDataAdded[self]) then -- fallback if pet action was not found in pet spell book by name.
 				tipDataAdded[self] = "petAction";
 				CustomTypeFuncs.petAction(self, nil, "petAction", nil, icon);
@@ -769,7 +769,7 @@ end
 -- HOOK: GameTooltip:SetRecipeReagentItem
 local function SetRecipeReagentItem_Hook(self, recipeID, reagentIndex)
 	if (cfg.if_enable) and (not tipDataAdded[self]) then
-		local link = C_TradeSkillUI.GetRecipeReagentItemLink(recipeID, reagentIndex);
+		local link = C_TradeSkillUI.GetRecipeFixedReagentItemLink(recipeID, reagentIndex);
 		if (link) then
 			local linkType, itemID = link:match("H?(%a+):(%d+)");
 			if (itemID) then
@@ -789,7 +789,7 @@ local function SetToyByItemID_Hook(self, itemID)
 			if (itemID) then
 				tipDataAdded[self] = linkType;
 				LinkTypeFuncs.item(self, link, linkType, itemID);
-				
+
 				-- apply workaround for first mouseover
 				ttif:ApplyWorkaroundForFirstMouseover(self, false, nil, link, linkType, itemID);
 			end
@@ -926,18 +926,18 @@ end
 local function SetAzeriteEssenceSlot_Hook(self, slot)
 	if (cfg.if_enable) and (not tipDataAdded[self]) then
 		local milestones = C_AzeriteEssence.GetMilestones();
-		
+
 		for i, milestoneInfo in ipairs(milestones) do
 			if (milestoneInfo.slot == slot) then
 				if (not milestoneInfo.unlocked) then
 					break;
 				end
-				
+
 				local milestoneID = milestoneInfo.ID;
 				local essenceID = C_AzeriteEssence.GetMilestoneEssence(milestoneID);
 				local essenceInfo = C_AzeriteEssence.GetEssenceInfo(essenceID);
 				local essenceRank = essenceInfo.rank;
-				
+
 				local link = C_AzeriteEssence.GetEssenceHyperlink(essenceID, essenceRank);
 				if (link) then
 					local linkType, _essenceID, _essenceRank = link:match("H?(%a+):(%d+):(%d+)");
@@ -949,7 +949,7 @@ local function SetAzeriteEssenceSlot_Hook(self, slot)
 						ttif:ApplyWorkaroundForFirstMouseover(self, false, nil, link, linkType, _essenceID, _essenceRank);
 					end
 				end
-				
+
 				break;
 			end
 		end
@@ -1132,7 +1132,7 @@ local function EITT_SetItemByQuestReward_Hook(self, questLogIndex, questID, rewa
 		if (not questLogIndex) then
 			return
 		end
-		
+
 		rewardType = (rewardType or "reward");
 		local getterFunc;
 		if (rewardType == "choice") then
@@ -1140,9 +1140,9 @@ local function EITT_SetItemByQuestReward_Hook(self, questLogIndex, questID, rewa
 		else
 			getterFunc = GetQuestLogRewardInfo;
 		end
-		
+
 		local name, texture, numItems, quality, isUsable, itemID = getterFunc(questLogIndex, questID);
-		
+
 		if (name) and (texture) then
 			local itemName, itemLink, itemRarity, itemLevel, itemMinLevel, itemType, itemSubType, itemStackCount, itemEquipLoc, itemTexture, itemSellPrice, classID, subClassID, bindType, expacID, setID, isCraftingReagent = GetItemInfo(itemID);
 			if (itemLink) then
@@ -1161,7 +1161,7 @@ local function EITT_SetSpellByQuestReward_Hook(self, rewardIndex, questID)
 	local targetTooltip = self.Tooltip;
 	if (cfg.if_enable) and (not tipDataAdded[targetTooltip]) and (targetTooltip:IsShown()) then
 		local texture, name, isTradeskillSpell, isSpellLearned, hideSpellLearnText, isBoostSpell, garrFollowerID, genericUnlock, spellID = GetQuestLogRewardSpell(rewardIndex, questID);
-		
+
 		if (name) and (texture) then
 			local link = GetSpellLink(spellID);
 			if (link) then
@@ -1325,7 +1325,7 @@ local function WCFICF_RefreshAppearanceTooltip_Hook(self)
 			local sources = CollectionWardrobeUtil.GetSortedAppearanceSources(self.tooltipVisualID, itemsCollectionFrame:GetActiveCategory(), itemsCollectionFrame.transmogLocation);
 			local index = CollectionWardrobeUtil.GetValidIndexForNumSources(wardrobeCollectionFrame.tooltipSourceIndex, #sources);
 			local sourceID = sources[index].sourceID;
-			
+
 			tipDataAdded[gtt] = "transmogappearance";
 			LinkTypeFuncs.transmogappearance(gtt, nil, "transmogappearance", sourceID);
 		end
@@ -1355,7 +1355,7 @@ local function WCFSCF_RefreshAppearanceTooltip_Hook(self)
 	if (cfg.if_enable) and (not tipDataAdded[gtt]) and (gtt:IsShown()) then
 		local setID = self:GetSelectedSetID();
 		local sourceID = self.tooltipPrimarySourceID;
-		
+
 		local sourceInfo = C_TransmogCollection.GetSourceInfo(sourceID);
 		local slot = C_Transmog.GetSlotForInventoryType(sourceInfo.invType);
 		local sources = C_TransmogSets.GetSourcesForSlot(setID, slot);
@@ -1369,7 +1369,7 @@ local function WCFSCF_RefreshAppearanceTooltip_Hook(self)
 		if (selectedIndex) then
 			local index = CollectionWardrobeUtil.GetValidIndexForNumSources(selectedIndex, #sources);
 			local _sourceID = sources[index].sourceID;
-			
+
 			tipDataAdded[gtt] = "transmogappearance";
 			LinkTypeFuncs.transmogappearance(gtt, nil, "transmogappearance", _sourceID);
 		end
@@ -1481,17 +1481,17 @@ function ttif:ApplyHooksToTips(tips, resolveGlobalNamedObjects, addToTipsToModif
 	if (resolveGlobalNamedObjects) then
 		ResolveGlobalNamedObjects(tips);
 	end
-	
+
 	-- apply necessary hooks to tips
 	for index, tip in ipairs(tips) do
 		if (type(tip) == "table") and (type(tip.GetObjectType) == "function") then
 			local tipName = tip:GetName();
 			local tipHooked = false;
-			
+
 			if (addToTipsToModify) then
 				tipsToModify[#tipsToModify + 1] = tip;
 			end
-			
+
 			if (tip:GetObjectType() == "GameTooltip") then
 				hooksecurefunc(tip, "SetHyperlink", function(self, ...)
 					ttif:SetHyperlink_Hook(self, ...)
@@ -1591,7 +1591,7 @@ function ttif:ApplyHooksToTips(tips, resolveGlobalNamedObjects, addToTipsToModif
 					end
 				end
 			end
-			
+
 			if (tipHooked) then
 				if (tipsToAddIcon[tipName]) then
 					self:CreateTooltipIcon(tip);
@@ -1638,17 +1638,17 @@ end
 -- AddOn Loaded
 function ttif:ADDON_LOADED(event, addOnName)
 	if (not cfg) then return end;
-	
+
 	-- check if addon is already loaded
 	if (addOnsLoaded[addOnName] == nil) or (addOnsLoaded[addOnName]) then
 		return;
 	end
-	
+
 	-- now AchievementFrameMiniAchievement exists
 	if (addOnName == "Blizzard_AchievementUI") or ((addOnName == "TipTacItemRef") and (IsAddOnLoaded("Blizzard_AchievementUI")) and (not addOnsLoaded['Blizzard_AchievementUI'])) then
 		if (isWoWSl) then -- df todo: function AchievementButton_GetMiniAchievement() doesn't exist in df.
 			local ABMAhooked = {}; -- see AchievementButton_GetMiniAchievement() in "Blizzard_AchievementUI/Blizzard_AchievementUI.lua"
-			
+
 			hooksecurefunc("AchievementButton_GetMiniAchievement", function(index)
 				local frame = _G["AchievementFrameMiniAchievement"..index];
 				if (frame) and (not ABMAhooked[frame]) then
@@ -1657,7 +1657,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 				end
 			end);
 		end
-		
+
 		if (addOnName == "TipTac") then
 			addOnsLoaded["Blizzard_AchievementUI"] = true;
 		end
@@ -1666,7 +1666,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 	if (addOnName == "Blizzard_Collections") or ((addOnName == "TipTacItemRef") and (IsAddOnLoaded("Blizzard_Collections")) and (not addOnsLoaded['Blizzard_Collections'])) then
 		pjpatt = PetJournalPrimaryAbilityTooltip;
 		pjsatt = PetJournalSecondaryAbilityTooltip;
-		
+
 		-- Hook Tips & Apply Settings
 		self:ApplyHooksToTips({
 			"PetJournalPrimaryAbilityTooltip",
@@ -1674,7 +1674,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 		}, true, true);
 
 		self:OnApplyConfig();
-		
+
 		-- Function to apply necessary hooks to WardrobeCollectionFrame.ItemsCollectionFrame, see WardrobeItemsCollectionMixin:UpdateItems() in "Blizzard_Collections/Blizzard_Wardrobe.lua"
 		hooksecurefunc(WardrobeCollectionFrame.ItemsCollectionFrame, "RefreshAppearanceTooltip", WCFICF_RefreshAppearanceTooltip_Hook); -- for items (incl. reapply for tabbing through items with same visualID)
 
@@ -1690,7 +1690,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 				for i = 1, itemsCollectionFrame.PAGE_SIZE do
 					local model = itemsCollectionFrame.Models[i];
 					local gttOwner = gtt:GetOwner();
-					
+
 					if (gttOwner == model) then
 						WCFICFM_OnEnter_Hook(gttOwner);
 						break;
@@ -1698,7 +1698,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 				end
 			end
 		end);
-		
+
 		-- Function to apply necessary hooks to WardrobeCollectionFrame.SetsCollectionFrame
 		hooksecurefunc(WardrobeCollectionFrame.SetsCollectionFrame, "RefreshAppearanceTooltip", WCFSCF_RefreshAppearanceTooltip_Hook); -- for sets (incl. reapply for tabbing through items with same visualID)
 
@@ -1708,7 +1708,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 			local model = setsTransmogFrame.Models[i];
 			hooksecurefunc(model, "RefreshTooltip", WCFSTFM_RefreshTooltip_Hook);
 		end
-		
+
 		if (addOnName == "TipTac") then
 			addOnsLoaded["Blizzard_Collections"] = true;
 		end
@@ -1719,11 +1719,11 @@ function ttif:ADDON_LOADED(event, addOnName)
 
 		-- Function to apply necessary hooks to CommunitiesFrameGuildDetailsFrameInfo
 		ttif:ApplyHooksToCFGDFI();
-		
+
 		hooksecurefunc("CommunitiesGuildInfoFrame_UpdateChallenges", function()
 			ttif:ApplyHooksToCFGDFI();
 		end);
-		
+
 		if (addOnName == "TipTac") then
 			addOnsLoaded["Blizzard_Communities"] = true;
 		end
@@ -1731,7 +1731,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 	-- now EncounterJournalTooltip exists
 	if (addOnName == "Blizzard_EncounterJournal") or ((addOnName == "TipTacItemRef") and (IsAddOnLoaded("Blizzard_EncounterJournal")) and (not addOnsLoaded['Blizzard_EncounterJournal'])) then
 		ejtt = EncounterJournalTooltip;
-		
+
 		-- Hook Tips & Apply Settings
 		-- commented out for embedded tooltips, see description in tt:SetPadding()
 		-- self:ApplyHooksToTips({
@@ -1739,7 +1739,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 		-- }, true, true);
 
 		-- self:OnApplyConfig();
-		
+
 		if (addOnName == "TipTac") then
 			addOnsLoaded["Blizzard_EncounterJournal"] = true;
 		end
@@ -1747,14 +1747,14 @@ function ttif:ADDON_LOADED(event, addOnName)
 	-- now GuildNewsButton exists
 	if (addOnName == "Blizzard_GuildUI") or ((addOnName == "TipTacItemRef") and (IsAddOnLoaded("Blizzard_GuildUI")) and (not addOnsLoaded['Blizzard_GuildUI'])) then
 		hooksecurefunc("GuildNewsButton_OnEnter", GNB_OnEnter_Hook);
-		
+
 		-- Function to apply necessary hooks to GuildInfoFrameInfoChallenge
 		ttif:ApplyHooksToGIFIC();
-		
+
 		hooksecurefunc("GuildInfoFrame_UpdateChallenges", function()
 			ttif:ApplyHooksToGIFIC();
 		end);
-		
+
 		if (addOnName == "TipTac") then
 			addOnsLoaded["Blizzard_GuildUI"] = true;
 		end
@@ -1762,7 +1762,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 	-- now PlayerChoiceTorghastOption exists
 	if (addOnName == "Blizzard_PlayerChoice") or ((addOnName == "TipTacItemRef") and (IsAddOnLoaded("Blizzard_PlayerChoice")) and (not addOnsLoaded['Blizzard_PlayerChoice'])) then
 		hooksecurefunc(PlayerChoicePowerChoiceTemplateMixin, "OnEnter", PCPCTM_OnEnter_Hook);
-		
+
 		if (addOnName == "TipTac") then
 			addOnsLoaded["Blizzard_PlayerChoice"] = true;
 		end
@@ -1777,11 +1777,11 @@ function ttif:ADDON_LOADED(event, addOnName)
 			HonorFrame.BonusFrame.BrawlButton,
 			HonorFrame.BonusFrame.BrawlButton2
 		};
-		
+
 		for i, button in pairs(buttons) do
 			button.Reward.EnlistmentBonus:HookScript("OnEnter", HFBFB_OnEnter);
 		end
-		
+
 		if (addOnName == "TipTac") then
 			addOnsLoaded["Blizzard_PVPUI"] = true;
 		end
@@ -1789,7 +1789,7 @@ function ttif:ADDON_LOADED(event, addOnName)
 	-- now WorldQuestTrackerAddon exists
 	if (addOnName == "WorldQuestTracker") or ((addOnName == "TipTacItemRef") and (IsAddOnLoaded("WorldQuestTracker")) and (not addOnsLoaded['WorldQuestTracker'])) then
 		local WQTThooked = {}; -- see WorldQuestTracker.GetOrCreateTrackerWidget() in "WorldQuestTracker/WorldQuestTracker_Tracker.lua"
-		
+
 		hooksecurefunc(WorldQuestTrackerAddon, "GetOrCreateTrackerWidget", function(index)
 			local frame = _G["WorldQuestTracker_Tracker" .. index];
 			if (frame) and (not WQTThooked[frame]) then
@@ -1797,24 +1797,24 @@ function ttif:ADDON_LOADED(event, addOnName)
 				WQTThooked[frame] = true;
 			end
 		end);
-		
+
 		if (addOnName == "TipTac") then
 			addOnsLoaded["WorldQuestTracker"] = true;
 		end
 	end
-	
+
 	addOnsLoaded[addOnName] = true;
-	
+
 	-- Cleanup if all addons are loaded
 	local allAddOnsLoaded = true;
-	
+
 	for addOn, isLoaded in pairs(addOnsLoaded) do
 		if (not isLoaded) then
 			allAddOnsLoaded = false;
 			break;
 		end
 	end
-	
+
 	if (allAddOnsLoaded) then
 		self:UnregisterEvent(event);
 		self[event] = nil;
@@ -1841,11 +1841,11 @@ local function SmartIconEvaluation(tip,linkType)
 		end
 		return true;
 	end
-	
+
 	if (tip == ejtt) then -- EncounterJournalTooltip
 		return false;
 	end
-	
+
 	local owner = tip:GetOwner();
 
 	-- No Owner?
@@ -1945,11 +1945,11 @@ function ttif:SetBackdropBorderColorLocked(tip, lockColor, r, g, b, a)
 	if (not lockColor) and (tip.ttBackdropBorderColorApplied) then
 		return;
 	end
-	
+
 	tip.ttSetBackdropBorderColorLocked = false;
 	tip:SetBackdropBorderColor(r, g, b, (a or 1) * ((cfg.tipBorderColor and cfg.tipBorderColor[4]) or 1));
 	tip.ttSetBackdropBorderColorLocked = true;
-	
+
 	if (lockColor) then
 		tip.ttBackdropBorderColorApplied = true;
 	end
@@ -2010,12 +2010,12 @@ function LinkTypeFuncs:item(link, linkType, id)
 							break;
 						end
 					end
-				else 
+				else
 					-- remove level from tip's line pool
 					for line in self.linePool:EnumerateActive() do
 						if (line and (line:GetText() or ""):match(ITEM_LEVEL_PLUS)) then
 							local linePredecessorPoint, linePredecessorRelativeTo, linePredecessorRelativePoint, linePredecessorXOfs, linePredecessorYOfs = line:GetPoint(1);
-							
+
 							if (line == self.textLineAnchor) then
 								-- last line in line pool
 								self.textLineAnchor = linePredecessorRelativeTo;
@@ -2023,7 +2023,7 @@ function LinkTypeFuncs:item(link, linkType, id)
 								-- re-anchor successor line
 								for successorLine in self.linePool:EnumerateActive() do
 									local successorLinePredecessorPoint, successorLinePredecessorRelativeTo, successorLinePredecessorRelativePoint, successorLinePredecessorXOfs, successorLinePredecessorYOfs = successorLine:GetPoint(1);
-									
+
 									if (successorLinePredecessorRelativeTo == line) then
 										local successorLineNumPoints = successorLine:GetNumPoints();
 										local successorLineLeftPoint, successorLineLeftRelativeTo, successorLineLeftRelativePoint, successorLineLeftXOfs, successorLineLeftYOfs = successorLine:GetPoint(2);
@@ -2032,7 +2032,7 @@ function LinkTypeFuncs:item(link, linkType, id)
 											successorLineRightPoint, successorLineRightRelativeTo, successorLineRightRelativePoint, successorLineRightXOfs, successorLineRightYOfs = successorLine:GetPoint(3);
 										end
 										successorLinePredecessorRelativeTo = linePredecessorRelativeTo;
-										
+
 										successorLine:ClearAllPoints();
 										successorLine:SetPoint(successorLinePredecessorPoint, successorLinePredecessorRelativeTo, successorLinePredecessorRelativePoint, successorLinePredecessorXOfs, successorLinePredecessorYOfs);
 										successorLine:SetPoint(successorLineLeftPoint, successorLineLeftRelativeTo, successorLineLeftRelativePoint, successorLineLeftXOfs, successorLineLeftYOfs);
@@ -2043,12 +2043,12 @@ function LinkTypeFuncs:item(link, linkType, id)
 									end
 								end
 							end
-							
+
 							-- remove level from tip's line pool
 							self:SetHeight(self:GetHeight() - line:GetHeight() - linePadding);
 							line:ClearAllPoints();
 							self.linePool:Release(line);
-							
+
 							break;
 						end
 					end
@@ -2112,7 +2112,7 @@ function LinkTypeFuncs:keystone(link, linkType, itemID, mapID, keystoneLevel, ..
 	local showWeeklyRewardLevel = (weeklyRewardLevel and cfg.if_showKeystoneRewardLevel);
 	local showTimeLimit = (mapID and cfg.if_showKeystoneTimeLimit);
 	local showAffixInfo = cfg.if_showKeystoneAffixInfo;
-	
+
 	if (showId or showRewardLevel or showWeeklyRewardLevel or showTimeLimit or showAffixInfo) then
 		local tipName = self:GetName();
 		local infoColorMixin = CreateColor(cfg.if_infoColor[1], cfg.if_infoColor[2], cfg.if_infoColor[3], (cfg.if_infoColor[4] or 1));
@@ -2120,7 +2120,7 @@ function LinkTypeFuncs:keystone(link, linkType, itemID, mapID, keystoneLevel, ..
 		if (showId) then
 			self:AddLine(format("ItemID: %d", itemID), unpack(cfg.if_infoColor));
 		end
-		
+
 		if (cfg.if_modifyKeystoneTips) then
 			local textRight2 = _G[tipName.."TextRight2"];
 			if (not showRewardLevel and showWeeklyRewardLevel) then
@@ -2140,7 +2140,7 @@ function LinkTypeFuncs:keystone(link, linkType, itemID, mapID, keystoneLevel, ..
 				self:AddLine(format("RewardLevel: %d", endOfRunRewardLevel), unpack(cfg.if_infoColor));
 			end
 		end
-		
+
 		if (showTimeLimit) then
 			local name, id, timeLimit, texture, backgroundTexture = C_ChallengeMode.GetMapUIInfo(mapID);
 			if (timeLimit) then
@@ -2153,7 +2153,7 @@ function LinkTypeFuncs:keystone(link, linkType, itemID, mapID, keystoneLevel, ..
 				end
 			end
 		end
-		
+
 		if (showAffixInfo) then
 			for i = 1, select('#', ...) do
 				local modifierID = select(i, ...);
@@ -2166,7 +2166,7 @@ function LinkTypeFuncs:keystone(link, linkType, itemID, mapID, keystoneLevel, ..
 				end
 			end
 		end
-		
+
 		self:Show();	-- call Show() to resize tip after adding lines
 	end
 end
@@ -2188,20 +2188,20 @@ function LinkTypeFuncs:spell(isAura, source, link, linkType, spellID)
 			end
 		end
 	end
-	
+
 	local isSpell = (not isAura);
 
 	-- Icon
 	if (not self.IsEmbedded) and (self.ttSetIconTextureAndText) and (not cfg.if_smartIcons or SmartIconEvaluation(self,linkType)) then
 		self:ttSetIconTextureAndText(icon);
 	end
-	
+
 	-- Caster
 	local showAuraCaster = (cfg.if_showAuraCaster and UnitExists(source));
 	if (showAuraCaster) then
 		self:AddLine(format("Caster: %s", UnitName(source) or UNKNOWNOBJECT), unpack(cfg.if_infoColor));
 	end
-	
+
 	-- MawPowerID and SpellID + Rank -- pre-16.08.25 only caster was formatted as this: "<Applied by %s>"
 	local showMawPowerID = (cfg.if_showMawPowerId and mawPowerID);
 	local showSpellIdAndRank = (((isSpell and cfg.if_showSpellIdAndRank) or (isAura and cfg.if_showAuraSpellIdAndRank)) and spellID and (spellID ~= 0));
@@ -2222,7 +2222,7 @@ function LinkTypeFuncs:spell(isAura, source, link, linkType, spellID)
   	-- Colored Border
 	if (not self.IsEmbedded) and ((isSpell and cfg.if_spellColoredBorder) or (isAura and cfg.if_auraSpellColoredBorder)) then
 		local spellColor = nil;
-		
+
 		if (mawPowerID and spellID) then
 			local rarityAtlas = C_Spell.GetMawPowerBorderAtlasBySpellID(spellID);
 			if (rarityAtlas) then
@@ -2237,11 +2237,11 @@ function LinkTypeFuncs:spell(isAura, source, link, linkType, spellID)
 				end
 			end
 		end
-		
+
 		if (not spellColor) then
 			spellColor = CreateColorFromHexString("FF71D5FF"); -- see GetSpellLink(). extraction of color code from this function not used, because in classic it only returns the spell name instead of a link.
 		end
-		
+
 		ttif:SetBackdropBorderColorLocked(self, true, spellColor:GetRGBA());
 	end
 end
@@ -2252,7 +2252,7 @@ function LinkTypeFuncs:mawpower(link, linkType, mawPowerID)
 	if (mawPowerID and table_MawPower_by_MawPowerID[mawPowerID]) then
 		spellID = table_MawPower_by_MawPowerID[mawPowerID].spellID;
 	end
-	
+
 	local name, _, icon, castTime, minRange, maxRange, _spellID = GetSpellInfo(spellID);	-- [18.07.19] 8.0/BfA: 2nd param "rank/nameSubtext" now returns nil
 	local rank = GetSpellSubtext(spellID);	-- will return nil at first unless its locally cached
 	rank = (rank and rank ~= "" and ", "..rank or "");
@@ -2261,7 +2261,7 @@ function LinkTypeFuncs:mawpower(link, linkType, mawPowerID)
 	if (self.ttSetIconTextureAndText) and (not cfg.if_smartIcons or SmartIconEvaluation(self,linkType)) then
 		self:ttSetIconTextureAndText(icon);
 	end
-	
+
 	-- MawPowerID and SpellID + Rank -- pre-16.08.25 only caster was formatted as this: "<Applied by %s>"
 	local showMawPowerID = (cfg.if_showMawPowerId and mawPowerID and (mawPowerID ~= 0));
 	local showSpellIdAndRank = (cfg.if_showSpellIdAndRank and spellID);
@@ -2279,7 +2279,7 @@ function LinkTypeFuncs:mawpower(link, linkType, mawPowerID)
   	-- Colored Border
 	if (cfg.if_spellColoredBorder) then
 		local spellColor = nil;
-		
+
 		if (mawPowerID and spellID) then
 			local rarityAtlas = C_Spell.GetMawPowerBorderAtlasBySpellID(spellID);
 			if (rarityAtlas) then
@@ -2294,11 +2294,11 @@ function LinkTypeFuncs:mawpower(link, linkType, mawPowerID)
 				end
 			end
 		end
-		
+
 		if (not spellColor) then
 			spellColor = CreateColorFromHexString("FF71D5FF"); -- see GetSpellLink(). extraction of color code from this function not used, because in classic it only returns the spell name instead of a link.
 		end
-		
+
 		ttif:SetBackdropBorderColorLocked(self, true, spellColor:GetRGBA());
 	end
 end
@@ -2319,11 +2319,11 @@ function LinkTypeFuncs:quest(link, linkType, questID, level)
 		end
 		self:Show();	-- call Show() to resize tip after adding lines
 	end
-	
+
   	-- Difficulty Border
 	if (cfg.if_questDifficultyBorder) then
 		local difficultyColorMixin;
-		
+
 		if (C_QuestLog.IsWorldQuest and C_QuestLog.IsWorldQuest(questID)) then -- see GameTooltip_AddQuest
 			local tagInfo = C_QuestLog.GetQuestTagInfo(questID);
 			local quality = tagInfo and tagInfo.quality or Enum.WorldQuestQuality.Common;
@@ -2332,7 +2332,7 @@ function LinkTypeFuncs:quest(link, linkType, questID, level)
 			local difficultyColor = GetDifficultyColor and GetDifficultyColor(C_PlayerInfo.GetContentDifficultyQuestForPlayer(questID)) or GetQuestDifficultyColor(level);
 			difficultyColorMixin = CreateColor(difficultyColor.r, difficultyColor.g, difficultyColor.b, 1);
 		end
-		
+
 		ttif:SetBackdropBorderColorLocked(self, true, difficultyColorMixin:GetRGBA());
 	end
 end
@@ -2343,7 +2343,7 @@ function LinkTypeFuncs:currency(link, linkType, currencyID, quantity)
 	local currencyInfo = nil;
 	local icon, quality;
 	local isCurrencyContainer = C_CurrencyInfo.IsCurrencyContainer and C_CurrencyInfo.IsCurrencyContainer(currencyID, _quantity);
-	
+
 	if (isCurrencyContainer) then
 		currencyInfo = C_CurrencyInfo.GetCurrencyContainerInfo(currencyID, _quantity);
 		icon = currencyInfo.icon;
@@ -2353,7 +2353,7 @@ function LinkTypeFuncs:currency(link, linkType, currencyID, quantity)
 		icon = currencyInfo.iconFileID;
 		quality = currencyInfo.quality;
 	end
-	
+
 	-- Icon
 	if (not self.IsEmbedded) and (self.ttSetIconTextureAndText) and (not cfg.if_smartIcons or SmartIconEvaluation(self,linkType)) then
 		if (currencyInfo) then
@@ -2504,20 +2504,20 @@ function LinkTypeFuncs:battlepet(link, linkType, speciesID, level, breedQuality,
 				-- remove level from tip
 				self:SetHeight(self:GetHeight() - self.Level:GetHeight() - linePadding);
 				self.Level:SetText(nil);
-				
+
 				-- re-anchor successor node
 				local levelPoint, levelRelativeTo, levelRelativePoint, levelXOfs, levelYOfs = self.Level:GetPoint();
 				local healthTexturePoint, healthTextureRelativeTo, healthTextureRelativePoint, healthTextureXOfs, healthTextureYOfs = self.HealthTexture:GetPoint();
 				healthTextureRelativeTo = levelRelativeTo;
-				
+
 				self.HealthTexture:ClearAllPoints();
 				self.HealthTexture:SetPoint(healthTexturePoint, healthTextureRelativeTo, healthTextureRelativePoint, healthTextureXOfs, healthTextureYOfs);
-				
+
 				-- remove level from tip's line pool
 				for line in self.linePool:EnumerateActive() do
 					if (line and (line:GetText() or ""):match(BATTLE_PET_CAGE_TOOLTIP_LEVEL)) then
 						local linePredecessorPoint, linePredecessorRelativeTo, linePredecessorRelativePoint, linePredecessorXOfs, linePredecessorYOfs = line:GetPoint(1);
-						
+
 						if (line == self.textLineAnchor) then
 							-- last line in line pool
 							self.textLineAnchor = linePredecessorRelativeTo;
@@ -2525,7 +2525,7 @@ function LinkTypeFuncs:battlepet(link, linkType, speciesID, level, breedQuality,
 							-- re-anchor successor line
 							for successorLine in self.linePool:EnumerateActive() do
 								local successorLinePredecessorPoint, successorLinePredecessorRelativeTo, successorLinePredecessorRelativePoint, successorLinePredecessorXOfs, successorLinePredecessorYOfs = successorLine:GetPoint(1);
-								
+
 								if (successorLinePredecessorRelativeTo == line) then
 									local successorLineNumPoints = successorLine:GetNumPoints();
 									local successorLineLeftPoint, successorLineLeftRelativeTo, successorLineLeftRelativePoint, successorLineLeftXOfs, successorLineLeftYOfs = successorLine:GetPoint(2);
@@ -2534,7 +2534,7 @@ function LinkTypeFuncs:battlepet(link, linkType, speciesID, level, breedQuality,
 										successorLineRightPoint, successorLineRightRelativeTo, successorLineRightRelativePoint, successorLineRightXOfs, successorLineRightYOfs = successorLine:GetPoint(3);
 									end
 									successorLinePredecessorRelativeTo = linePredecessorRelativeTo;
-									
+
 									successorLine:ClearAllPoints();
 									successorLine:SetPoint(successorLinePredecessorPoint, successorLinePredecessorRelativeTo, successorLinePredecessorRelativePoint, successorLinePredecessorXOfs, successorLinePredecessorYOfs);
 									successorLine:SetPoint(successorLineLeftPoint, successorLineLeftRelativeTo, successorLineLeftRelativePoint, successorLineLeftXOfs, successorLineLeftYOfs);
@@ -2545,12 +2545,12 @@ function LinkTypeFuncs:battlepet(link, linkType, speciesID, level, breedQuality,
 								end
 							end
 						end
-						
+
 						-- remove level from tip's line pool
 						self:SetHeight(self:GetHeight() - line:GetHeight() - linePadding);
 						line:ClearAllPoints();
 						self.linePool:Release(line);
-						
+
 						break;
 					end
 				end
@@ -2564,7 +2564,7 @@ function LinkTypeFuncs:battlepet(link, linkType, speciesID, level, breedQuality,
 				end
 			end
 		end
-		
+
 		if (not showLevel) then
 			self:AddLine(format("NPC ID: %d", tonumber(creatureID)), unpack(cfg.if_infoColor));
 		elseif (showId) then
@@ -2577,15 +2577,15 @@ function LinkTypeFuncs:battlepet(link, linkType, speciesID, level, breedQuality,
 			self:Show();	-- call Show() to resize tip after adding lines. only necessary for pet tooltip in action bar.
 		end
 	end
-	
+
 	if (not showLevel) then
 		if (self == bptt or self == fbptt) then
 			-- re-anchor successor node if necessary
 			local healthTexturePoint, healthTextureRelativeTo, healthTextureRelativePoint, healthTextureXOfs, healthTextureYOfs = self.HealthTexture:GetPoint();
-			
+
 			if (healthTextureRelativeTo ~= self.Level) then
 				healthTextureRelativeTo = self.Level;
-				
+
 				self.HealthTexture:ClearAllPoints();
 				self.HealthTexture:SetPoint(healthTexturePoint, healthTextureRelativeTo, healthTextureRelativePoint, healthTextureXOfs, healthTextureYOfs);
 			end
@@ -2627,7 +2627,7 @@ function LinkTypeFuncs:conduit(link, linkType, conduitID, conduitRank)
 	-- ItemLevel + ConduitID
 	local conduitCollectionData = C_Soulbinds.GetConduitCollectionData(conduitID);
 	local conduitItemLevel = (conduitCollectionData and conduitCollectionData.conduitItemLevel); -- conduitCollectionData is only available for own conduits
-	
+
 	local showLevel = (conduitItemLevel and cfg.if_showConduitItemLevel);
 	local showId = (conduitID and cfg.if_showConduitId);
 
@@ -2641,7 +2641,7 @@ function LinkTypeFuncs:conduit(link, linkType, conduitID, conduitRank)
 				end
 			end
 		end
-		
+
 		if (not showLevel) then
 			self:AddLine(format("ConduitID: %d", conduitID), unpack(cfg.if_infoColor));
 		elseif (showId) then
@@ -2699,7 +2699,7 @@ end
 -- transmog illusion
 function LinkTypeFuncs:transmogillusion(link, linkType, illusionID)
 	local illusionInfo = C_TransmogCollection.GetIllusionInfo(illusionID);
-	
+
 	-- Icon
 	if (self.ttSetIconTextureAndText) and (not cfg.if_smartIcons or SmartIconEvaluation(self, linkType)) then
 		self:ttSetIconTextureAndText(illusionInfo.icon);
@@ -2727,7 +2727,7 @@ function LinkTypeFuncs:transmogset(link, linkType, setID)
 	local waitingOnQuality = false;
 	local sourceQualityTable = {};
 	local primaryAppearances = C_TransmogSets.GetSetPrimaryAppearances(setID);
-	
+
 	for i, primaryAppearance in pairs(primaryAppearances) do
 		numTotalSlots = numTotalSlots + 1;
 		local sourceID = primaryAppearance.appearanceID;
@@ -2743,12 +2743,12 @@ function LinkTypeFuncs:transmogset(link, linkType, setID)
 			end
 		end
 	end
-	
+
 	if (waitingOnQuality) then
 		tipDataAdded[self] = nil;
 		return;
 	end
-	
+
 	-- Icon
 	if (self.ttSetIconTextureAndText) and (not cfg.if_smartIcons or SmartIconEvaluation(self, linkType)) then
 		local SetsDataProvider = CreateFromMixins(WardrobeSetsDataProviderMixin);
@@ -2773,7 +2773,7 @@ end
 -- azerite essence
 function LinkTypeFuncs:azessence(link, linkType, essenceID, essenceRank)
 	local essenceInfo = C_AzeriteEssence.GetEssenceInfo(essenceID);
-	
+
 	-- Icon
 	if (self.ttSetIconTextureAndText) and (not cfg.if_smartIcons or SmartIconEvaluation(self, linkType)) then
 		self:ttSetIconTextureAndText(essenceInfo.icon);
@@ -2799,7 +2799,7 @@ end
 -- runeforge power
 function CustomTypeFuncs:runeforgePower(link, linkType, runeforgePowerID)
 	local powerInfo = C_LegendaryCrafting.GetRuneforgePowerInfo(runeforgePowerID);
-	
+
 	-- Icon
 	if (self.ttSetIconTextureAndText) and (not cfg.if_smartIcons or SmartIconEvaluation(self, linkType)) then
 		self:ttSetIconTextureAndText(powerInfo.iconFileID);


### PR DESCRIPTION
According to [https://wowpedia.fandom.com/wiki/Patch_10.0.0/API_changes](https://wowpedia.fandom.com/wiki/Patch_10.0.0/API_changes) `Update C_TradeSkillUI.GetRecipeReagentItemLink` is removed and actuall errors out on the reagents on Pascal-K1N6 in Mechagon for example.