### PR TITLE
feat: add option to only hide spells tips

### DIFF
--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -1395,6 +1395,18 @@ local function isHideTip(tooltip, calledFromEvent)
 				end
 			end
 		end
+
+		if (calledFromEvent == "OnTooltipSetSpell") then
+			if (cfg.hideTips == "spells") then
+				return true
+			end
+
+			if (isInCombat) then
+				if (cfg.hideTipsInCombat == "spells") then
+					return true;
+				end
+			end
+		end
 	end
 	
 	return false;
@@ -1514,6 +1526,14 @@ function gttScriptHooks:OnTooltipSetUnit()
 	-- We're done, apply appearance
 	self.ttUnit.token = unit;
 	tt:ApplyUnitAppearance(self,true);	-- called with "first" arg to true
+end
+
+-- EventHook: OnTooltipSetSpell
+function gttScriptHooks:OnTooltipSetSpell()
+	-- Check if tooltip has to be set hidden
+	if (isHideTip(self, "OnTooltipSetSpell")) then
+		self:Hide();
+	end
 end
 
 -- EventHook: OnTooltipCleared -- This will clean up auras, bars, raid icon and vars for the gtt when we aren't showing a unit
@@ -1874,6 +1894,12 @@ function tt:ApplyHooksToTips(tips, resolveGlobalNamedObjects, addToTipsToModify)
 							TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, function(self, ...)
 								if (self == tip) then
 									gttScriptHooks.OnTooltipSetItem(self, ...);
+								end
+							end);
+						elseif (scriptName == "OnTooltipSetSpell") then
+							TooltipDataProcessor.AddTooltipPostCall(Enum.TooltipDataType.Item, function(self, ...)
+								if (self == tip) then
+									gttScriptHooks.OnTooltipSetSpell(self, ...);
 								end
 							end);
 						else

--- a/TipTacOptions/ttOptions.lua
+++ b/TipTacOptions/ttOptions.lua
@@ -257,8 +257,8 @@ local options = {
 	-- Combat
 	{
 		[0] = "Combat",
-		{ type = "DropDown", var = "hideTips", label = "Hide Tips", list = { ["Frame Units"] = "fu", ["World Units"] = "wu", ["Frame + World Units"] = "fwu", ["All Tips"] = "all", ["No Tips"] = "none" } },
-		{ type = "DropDown", var = "hideTipsInCombat", label = "Hide Tips in Combat", list = { ["Frame Units"] = "fu", ["World Units"] = "wu", ["Frame + World Units"] = "fwu", ["All Tips"] = "all", ["No Tips"] = "none" } },
+		{ type = "DropDown", var = "hideTips", label = "Hide Tips", list = { ["Frame Units"] = "fu", ["World Units"] = "wu", ["Frame + World Units"] = "fwu", ["Spells"] = "spells", ["All Tips"] = "all", ["No Tips"] = "none" } },
+		{ type = "DropDown", var = "hideTipsInCombat", label = "Hide Tips in Combat", list = { ["Frame Units"] = "fu", ["World Units"] = "wu", ["Frame + World Units"] = "fwu", ["Spells"] = "spells", ["All Tips"] = "all", ["No Tips"] = "none" } },
 		{ type = "Check", var = "showHiddenTipsOnShift", label = "Still Show Hidden Tips when Holding Shift", tip = "When you have this option checked, and one of the above options, you can still force the tip to show, by holding down shift", y = 8 },
 	},
 	-- Layouts


### PR DESCRIPTION
Hello, I added an option to be able to hide only "spell" type tooltips, very practical for mouse clickers for example :yum: 