### PR TITLE
3.4.3 Taint Fixes

### DIFF
--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -571,12 +571,12 @@ TT_ExtendedConfig.tipsToModify = {
 		},
 		hookFnForAddOn = function(TT_CacheForFrames)
 			-- HOOK: SharedPetBattleAbilityTooltip_UpdateSize() to re-hook OnUpdate for PetJournalPrimaryAbilityTooltip and PetJournalSecondaryAbilityTooltip
-			hooksecurefunc("SharedPetBattleAbilityTooltip_UpdateSize", function(self)
+			--hooksecurefunc("SharedPetBattleAbilityTooltip_UpdateSize", function(self)
 				-- re-hook OnUpdate for PetJournalPrimaryAbilityTooltip and PetJournalSecondaryAbilityTooltip to anchor tip to mouse position
 				if (LibFroznFunctions:ExistsInTable(self, { PetJournalPrimaryAbilityTooltip, PetJournalSecondaryAbilityTooltip })) then
 					tt:AnchorTipToMouseOnUpdate(self);
 				end
-			end);
+			--end;
 		end
 	},
 	["Blizzard_Communities"] = {

--- a/TipTacItemRef/ttItemRef.lua
+++ b/TipTacItemRef/ttItemRef.lua
@@ -1997,15 +1997,15 @@ function ttif:ADDON_LOADED(event, addOnName, containsBindings)
 		self:OnApplyConfig();
 		
 		-- Function to apply necessary hooks to WardrobeCollectionFrame.ItemsCollectionFrame, see WardrobeItemsCollectionMixin:UpdateItems() in "Blizzard_Collections/Blizzard_Wardrobe.lua"
-		hooksecurefunc(WardrobeCollectionFrame.ItemsCollectionFrame, "RefreshAppearanceTooltip", WCFICF_RefreshAppearanceTooltip_Hook); -- for items (incl. reapply for tabbing through items with same visualID)
+		--hooksecurefunc(WardrobeCollectionFrame.ItemsCollectionFrame, "RefreshAppearanceTooltip", WCFICF_RefreshAppearanceTooltip_Hook); -- for items (incl. reapply for tabbing through items with same visualID)
 
-		local itemsCollectionFrame = WardrobeCollectionFrame.ItemsCollectionFrame; -- for illusions
-		for i = 1, itemsCollectionFrame.PAGE_SIZE do
-			local model = itemsCollectionFrame.Models[i];
-			model:HookScript("OnEnter", WCFICFM_OnEnter_Hook);
-		end
+		--local itemsCollectionFrame = WardrobeCollectionFrame.ItemsCollectionFrame; -- for illusions
+		--for i = 1, itemsCollectionFrame.PAGE_SIZE do
+		--	local model = itemsCollectionFrame.Models[i];
+		--	model:HookScript("OnEnter", WCFICFM_OnEnter_Hook);
+		--end
 
-		hooksecurefunc(WardrobeCollectionFrame.ItemsCollectionFrame, "UpdateItems", function(self) -- reapply if selecting or scrolling
+		--hooksecurefunc(WardrobeCollectionFrame.ItemsCollectionFrame, "UpdateItems", function(self) -- reapply if selecting or scrolling
 			if (gtt:IsShown()) then
 				local itemsCollectionFrame = self;
 				for i = 1, itemsCollectionFrame.PAGE_SIZE do
@@ -2017,18 +2017,18 @@ function ttif:ADDON_LOADED(event, addOnName, containsBindings)
 						break;
 					end
 				end
-			end
-		end);
+		--	end
+		end;
 		
 		-- Function to apply necessary hooks to WardrobeCollectionFrame.SetsCollectionFrame
-		hooksecurefunc(WardrobeCollectionFrame.SetsCollectionFrame, "RefreshAppearanceTooltip", WCFSCF_RefreshAppearanceTooltip_Hook); -- for sets (incl. reapply for tabbing through items with same visualID)
+		-- hooksecurefunc(WardrobeCollectionFrame.SetsCollectionFrame, "RefreshAppearanceTooltip", WCFSCF_RefreshAppearanceTooltip_Hook); -- for sets (incl. reapply for tabbing through items with same visualID)
 
 		-- Function to apply necessary hooks to WardrobeCollectionFrame.SetsTransmogFrame, see WardrobeSetsTransmogMixin:UpdateSets() in "Blizzard_Collections/Blizzard_Wardrobe.lua"
-		local setsTransmogFrame = WardrobeCollectionFrame.SetsTransmogFrame; -- for sets at transmogrifier
-		for i = 1, setsTransmogFrame.PAGE_SIZE do
-			local model = setsTransmogFrame.Models[i];
-			hooksecurefunc(model, "RefreshTooltip", WCFSTFM_RefreshTooltip_Hook);
-		end
+		--local setsTransmogFrame = WardrobeCollectionFrame.SetsTransmogFrame; -- for sets at transmogrifier
+		--for i = 1, setsTransmogFrame.PAGE_SIZE do
+		--	local model = setsTransmogFrame.Models[i];
+		--	hooksecurefunc(model, "RefreshTooltip", WCFSTFM_RefreshTooltip_Hook);
+		--end
 		
 		if (addOnName == MOD_NAME) then
 			addOnsLoaded["Blizzard_Collections"] = true;


### PR DESCRIPTION
3.4.3 Blizzard have enabled Blizzard_Collections.lua but only for Mounts/Pets/Toys/Heirlooms. 

This fixes the attempts to hooksecure and resulting taint for the not yet available PetBattle, ItemCollection, SetsCollection and Transmog frames

Closes: https://github.com/frozn/TipTac/issues/260