### PR TITLE
Fix `IsAddOnLoaded` in LibFroznFunctions

### DIFF
--- a/TipTac/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTac/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -23,6 +23,8 @@ if (not LibFroznFunctions) then
 	return;
 end
 
+local IsAddOnLoaded = (C_AddOns and C_AddOns.IsAddOnLoaded) and C_AddOns.IsAddOnLoaded or IsAddOnLoaded
+
 ----------------------------------------------------------------------------------------------------
 --                                           Table API                                            --
 ----------------------------------------------------------------------------------------------------

--- a/TipTacItemRef/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacItemRef/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -23,6 +23,8 @@ if (not LibFroznFunctions) then
 	return;
 end
 
+local IsAddOnLoaded = (C_AddOns and C_AddOns.IsAddOnLoaded) and C_AddOns.IsAddOnLoaded or IsAddOnLoaded
+
 ----------------------------------------------------------------------------------------------------
 --                                           Table API                                            --
 ----------------------------------------------------------------------------------------------------

--- a/TipTacOptions/Libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacOptions/Libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -23,6 +23,8 @@ if (not LibFroznFunctions) then
 	return;
 end
 
+local IsAddOnLoaded = (C_AddOns and C_AddOns.IsAddOnLoaded) and C_AddOns.IsAddOnLoaded or IsAddOnLoaded
+
 ----------------------------------------------------------------------------------------------------
 --                                           Table API                                            --
 ----------------------------------------------------------------------------------------------------

--- a/TipTacTalents/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacTalents/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -23,6 +23,8 @@ if (not LibFroznFunctions) then
 	return;
 end
 
+local IsAddOnLoaded = (C_AddOns and C_AddOns.IsAddOnLoaded) and C_AddOns.IsAddOnLoaded or IsAddOnLoaded
+
 ----------------------------------------------------------------------------------------------------
 --                                           Table API                                            --
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
[`IsAddOnLoaded `](https://warcraft.wiki.gg/wiki/API_IsAddOnLoaded) will be removed in favor of `C_AddOns.IsAddOnLoaded` in the 11.0.2 patch. This fixes the addon erroring on the beta client.