### PR TITLE
fix: playerGuildClubMemberIDs now checked if it is a secret value

### DIFF
--- a/TipTac/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTac/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -4360,12 +4360,14 @@ function LibFroznFunctions:GetPlayerGuildClubMemberInfo(unitGUID)
 			if (playerGuildClubIDCache) then
 				local playerGuildClubMemberIDs = C_Club.GetClubMembers(playerGuildClubIDCache);
 				
-				for _, playerGuildClubMemberID in ipairs(playerGuildClubMemberIDs) do
-					local playerGuildClubMemberInfo = C_Club.GetMemberInfo(playerGuildClubIDCache, playerGuildClubMemberID);
-					
-					if (playerGuildClubMemberInfo) and (playerGuildClubMemberInfo.guid) then
-						playerGuildClubMemberInfosCache[playerGuildClubMemberInfo.guid] = playerGuildClubMemberInfo;
-					end
+				if (not LibFroznFunctions:IsSecretValue(playerGuildClubMemberIDs)) then
+    				for _, playerGuildClubMemberID in ipairs(playerGuildClubMemberIDs) do
+    					local playerGuildClubMemberInfo = C_Club.GetMemberInfo(playerGuildClubIDCache, playerGuildClubMemberID);
+
+    					if (playerGuildClubMemberInfo) and (playerGuildClubMemberInfo.guid) then
+    						playerGuildClubMemberInfosCache[playerGuildClubMemberInfo.guid] = playerGuildClubMemberInfo;
+    					end
+    				end
 				end
 			end
 		end

--- a/TipTacItemRef/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacItemRef/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -4360,12 +4360,14 @@ function LibFroznFunctions:GetPlayerGuildClubMemberInfo(unitGUID)
 			if (playerGuildClubIDCache) then
 				local playerGuildClubMemberIDs = C_Club.GetClubMembers(playerGuildClubIDCache);
 				
-				for _, playerGuildClubMemberID in ipairs(playerGuildClubMemberIDs) do
-					local playerGuildClubMemberInfo = C_Club.GetMemberInfo(playerGuildClubIDCache, playerGuildClubMemberID);
-					
-					if (playerGuildClubMemberInfo) and (playerGuildClubMemberInfo.guid) then
-						playerGuildClubMemberInfosCache[playerGuildClubMemberInfo.guid] = playerGuildClubMemberInfo;
-					end
+				if (not LibFroznFunctions:IsSecretValue(playerGuildClubMemberIDs)) then
+    				for _, playerGuildClubMemberID in ipairs(playerGuildClubMemberIDs) do
+    					local playerGuildClubMemberInfo = C_Club.GetMemberInfo(playerGuildClubIDCache, playerGuildClubMemberID);
+
+    					if (playerGuildClubMemberInfo) and (playerGuildClubMemberInfo.guid) then
+    						playerGuildClubMemberInfosCache[playerGuildClubMemberInfo.guid] = playerGuildClubMemberInfo;
+    					end
+    				end
 				end
 			end
 		end

--- a/TipTacOptions/Libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacOptions/Libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -4360,12 +4360,14 @@ function LibFroznFunctions:GetPlayerGuildClubMemberInfo(unitGUID)
 			if (playerGuildClubIDCache) then
 				local playerGuildClubMemberIDs = C_Club.GetClubMembers(playerGuildClubIDCache);
 				
-				for _, playerGuildClubMemberID in ipairs(playerGuildClubMemberIDs) do
-					local playerGuildClubMemberInfo = C_Club.GetMemberInfo(playerGuildClubIDCache, playerGuildClubMemberID);
-					
-					if (playerGuildClubMemberInfo) and (playerGuildClubMemberInfo.guid) then
-						playerGuildClubMemberInfosCache[playerGuildClubMemberInfo.guid] = playerGuildClubMemberInfo;
-					end
+				if (not LibFroznFunctions:IsSecretValue(playerGuildClubMemberIDs)) then
+    				for _, playerGuildClubMemberID in ipairs(playerGuildClubMemberIDs) do
+    					local playerGuildClubMemberInfo = C_Club.GetMemberInfo(playerGuildClubIDCache, playerGuildClubMemberID);
+
+    					if (playerGuildClubMemberInfo) and (playerGuildClubMemberInfo.guid) then
+    						playerGuildClubMemberInfosCache[playerGuildClubMemberInfo.guid] = playerGuildClubMemberInfo;
+    					end
+    				end
 				end
 			end
 		end

--- a/TipTacTalents/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacTalents/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -4360,12 +4360,14 @@ function LibFroznFunctions:GetPlayerGuildClubMemberInfo(unitGUID)
 			if (playerGuildClubIDCache) then
 				local playerGuildClubMemberIDs = C_Club.GetClubMembers(playerGuildClubIDCache);
 				
-				for _, playerGuildClubMemberID in ipairs(playerGuildClubMemberIDs) do
-					local playerGuildClubMemberInfo = C_Club.GetMemberInfo(playerGuildClubIDCache, playerGuildClubMemberID);
-					
-					if (playerGuildClubMemberInfo) and (playerGuildClubMemberInfo.guid) then
-						playerGuildClubMemberInfosCache[playerGuildClubMemberInfo.guid] = playerGuildClubMemberInfo;
-					end
+				if (not LibFroznFunctions:IsSecretValue(playerGuildClubMemberIDs)) then
+    				for _, playerGuildClubMemberID in ipairs(playerGuildClubMemberIDs) do
+    					local playerGuildClubMemberInfo = C_Club.GetMemberInfo(playerGuildClubIDCache, playerGuildClubMemberID);
+
+    					if (playerGuildClubMemberInfo) and (playerGuildClubMemberInfo.guid) then
+    						playerGuildClubMemberInfosCache[playerGuildClubMemberInfo.guid] = playerGuildClubMemberInfo;
+    					end
+    				end
 				end
 			end
 		end


### PR DESCRIPTION
# CHANGELOG 
1. `playerGuildClubMemberIDs` argument to `ipairs` is now checked for secret.