### PR TITLE
fix: use non-member issecretvalue for frameForDelayedInspection

### DIFF
--- a/TipTac/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTac/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -4518,7 +4518,7 @@ end
 -- get record in unit cache
 function frameForDelayedInspection:GetUnitCacheRecord(unitID, unitGUID)
 	-- no unit guid or unit guid is a secret value
-	if (self:IsSecretValue(unitGUID)) or (not unitGUID) then
+	if (issecretvalue(unitGUID)) or (not unitGUID) then
 		return;
 	end
 	

--- a/TipTacItemRef/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacItemRef/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -4518,7 +4518,7 @@ end
 -- get record in unit cache
 function frameForDelayedInspection:GetUnitCacheRecord(unitID, unitGUID)
 	-- no unit guid or unit guid is a secret value
-	if (self:IsSecretValue(unitGUID)) or (not unitGUID) then
+	if (issecretvalue(unitGUID)) or (not unitGUID) then
 		return;
 	end
 	

--- a/TipTacOptions/Libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacOptions/Libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -4518,7 +4518,7 @@ end
 -- get record in unit cache
 function frameForDelayedInspection:GetUnitCacheRecord(unitID, unitGUID)
 	-- no unit guid or unit guid is a secret value
-	if (self:IsSecretValue(unitGUID)) or (not unitGUID) then
+	if (issecretvalue(unitGUID)) or (not unitGUID) then
 		return;
 	end
 	

--- a/TipTacTalents/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
+++ b/TipTacTalents/libs/LibFroznFunctions-1.0/LibFroznFunctions-1.0.lua
@@ -4518,7 +4518,7 @@ end
 -- get record in unit cache
 function frameForDelayedInspection:GetUnitCacheRecord(unitID, unitGUID)
 	-- no unit guid or unit guid is a secret value
-	if (self:IsSecretValue(unitGUID)) or (not unitGUID) then
+	if (issecretvalue(unitGUID)) or (not unitGUID) then
 		return;
 	end
 	


### PR DESCRIPTION
1. `frameForDelayedInspection` doesn't have member function `IsSecretValue`