### PR TITLE
attempt to index local 'unitRecord' (a nil value)

### DIFF
--- a/TipTacItemRef/ttItemRef.lua
+++ b/TipTacItemRef/ttItemRef.lua
@@ -3252,19 +3252,19 @@ function LinkTypeFuncs:unit(link, linkType, unitID, unitGUID)
 	local npcID;
 	
 	if (unitID) then
-		local unitRecord = LibFroznFunctions:GetUnitRecordFromCache(unitID)
+		local unitRecord = LibFroznFunctions:GetUnitRecordFromCache(unitID);
 		
 		if (unitRecord) then
-			npcID = unitRecord.npcID
+			npcID = unitRecord.npcID;
 		end
 	end
 	
 	-- If unitRecord wasn't found (npcID is still nil) and we have a GUID, try the fallback
 	if (not npcID and unitGUID) then
-		local unitType, _, serverID, instanceID, zoneUID, ID, spawnUID = ("-"):split(unitGUID)
+		local unitType, _, serverID, instanceID, zoneUID, ID, spawnUID = ("-"):split(unitGUID);
 		
 		if (LibFroznFunctions:ExistsInTable(unitType, { "Creature", "Pet", "GameObject", "Vehicle" })) then
-			npcID = ID
+			npcID = ID;
 		end
 	end
 	


### PR DESCRIPTION
fix: add nil check for unitRecord and implement GUID fallback

Prevents a crash when GetUnitRecordFromCache returns nil by allowing the logic to fall back to parsing the unitGUID.

#495