### PR TITLE
Workaround on ttAuras and ttCores issues

### DIFF
--- a/TipTac/TipTac.toc
+++ b/TipTac/TipTac.toc
@@ -1,9 +1,9 @@
 ## Interface: 120001
-## Version: 26.03.16.1
+## Version: 26.03.16.2
 ## IconTexture: Interface\AddOns\TipTac\media\tiptac_logo
-## Title: TipTac (Secret Fix)
+## Title: TipTac (Temp fix)
 ## Author: Frozn45, Aezay (Earthen Ring EU)
-## Notes: Highly Customizable Tooltip Enhancement Addon - hotfix for Midnight secret tooltip errors
+## Notes: Highly Customizable Tooltip Enhancement Addon - Temporary fix for Midnight secret tooltip errors
 ## Category-enUS: User Interface
 ## Category-deDE: Benutzerinterface
 ## Category-esES: Interfaz de usuario

--- a/TipTac/TipTac.toc
+++ b/TipTac/TipTac.toc
@@ -1,9 +1,9 @@
 ## Interface: 120001
-## Version: 26.03.16
+## Version: 26.03.16.1
 ## IconTexture: Interface\AddOns\TipTac\media\tiptac_logo
-## Title: TipTac
+## Title: TipTac (Secret Fix)
 ## Author: Frozn45, Aezay (Earthen Ring EU)
-## Notes: Highly Customizable Tooltip Enhancement Addon
+## Notes: Highly Customizable Tooltip Enhancement Addon - hotfix for Midnight secret tooltip errors
 ## Category-enUS: User Interface
 ## Category-deDE: Benutzerinterface
 ## Category-esES: Interfaz de usuario

--- a/TipTac/modules/ttAuras.lua
+++ b/TipTac/modules/ttAuras.lua
@@ -131,15 +131,17 @@ function ttAuras:SetupUnitTipsAuras(tip)
 	if (offsetForClampRectInsets > 0) then
 		local leftOffset, rightOffset, topOffset, bottomOffset = tip:GetClampRectInsets();
 		
-		if (cfg.aurasAtBottom) then
-			if (bottomOffset > -offsetForClampRectInsets) then
-				-- set clamp rect insets to tip for preventing additional elements from moving off-screen
-				LibFroznFunctions:FireGroupEvent(MOD_NAME, "SetClampRectInsetsToTip", tip, leftOffset, rightOffset, topOffset, -offsetForClampRectInsets);
-			end
-		else
-			if (topOffset < offsetForClampRectInsets) then
-				-- set clamp rect insets to tip for preventing additional elements from moving off-screen
-				LibFroznFunctions:FireGroupEvent(MOD_NAME, "SetClampRectInsetsToTip", tip, leftOffset, rightOffset, offsetForClampRectInsets, bottomOffset);
+		if (not LibFroznFunctions:IsSecretValue(leftOffset)) and (not LibFroznFunctions:IsSecretValue(rightOffset)) and (not LibFroznFunctions:IsSecretValue(topOffset)) and (not LibFroznFunctions:IsSecretValue(bottomOffset)) then
+			if (cfg.aurasAtBottom) then
+				if (bottomOffset > -offsetForClampRectInsets) then
+					-- set clamp rect insets to tip for preventing additional elements from moving off-screen
+					LibFroznFunctions:FireGroupEvent(MOD_NAME, "SetClampRectInsetsToTip", tip, leftOffset, rightOffset, topOffset, -offsetForClampRectInsets);
+				end
+			else
+				if (topOffset < offsetForClampRectInsets) then
+					-- set clamp rect insets to tip for preventing additional elements from moving off-screen
+					LibFroznFunctions:FireGroupEvent(MOD_NAME, "SetClampRectInsetsToTip", tip, leftOffset, rightOffset, offsetForClampRectInsets, bottomOffset);
+				end
 			end
 		end
 	end

--- a/TipTac/modules/ttBars.lua
+++ b/TipTac/modules/ttBars.lua
@@ -50,6 +50,23 @@ function ttBars:OnConfigLoaded(_TT_CacheForFrames, _configDb, _cfg, _TT_Extended
 	configDb = _configDb;
 	cfg = _cfg;
 	TT_ExtendedConfig = _TT_ExtendedConfig;
+	
+	-- hook GameTooltipStatusBar to keep it hidden when configured. this is
+	-- needed because Blizzard's internal (untainted) code can re-show the
+	-- status bar after TipTac has hidden it, e.g. during tooltip refreshes in
+	-- instance combat with secret values, or during the Show() call that
+	-- follows SetUnit() in the tooltip lifecycle.
+	if (not self.defaultStatusBarHooked) then
+		local statusBar = GameTooltipStatusBar;
+		if (statusBar) then
+			statusBar:HookScript("OnShow", function(self)
+				if (cfg) and (cfg.hideDefaultBar) and (not self:IsForbidden()) then
+					self:Hide();
+				end
+			end);
+			self.defaultStatusBarHooked = true;
+		end
+	end
 end
 
 -- config settings need to be applied
@@ -259,12 +276,6 @@ function ttBars:DisplayUnitTipsBar(barsPool, frameParams, tip, unitRecord, offse
 	local newOffsetY = offsetY;
 	
 	if (bar:GetVisibility(tip, unitRecord)) then
-		-- The first visible bar needs to reserve the initial bottom anchor margin as well,
-		-- otherwise the tooltip's last text line can overlap the top of the bar stack.
-		if (frameParams.currentDisplayParams.extraPaddingBottomForBars == 0) then
-			frameParams.currentDisplayParams.extraPaddingBottomForBars = TT_GTT_BARS_MARGIN_Y - TT_GTT_BARS_SPACING;
-		end
-		
 		-- initialize anchoring position and color
 		bar:ClearAllPoints();
 		

--- a/TipTac/modules/ttBars.lua
+++ b/TipTac/modules/ttBars.lua
@@ -247,6 +247,14 @@ function ttBars:SetupUnitTipsBars(tip)
 		return;
 	end
 	
+	-- don't show bars when tooltip padding can't be applied — bars would
+	-- overlap text because SetPaddingToTip bails out under the same guards.
+	-- this also covers the case where HasTipTaintedWidgetContainer() persists
+	-- after leaving an instance (tainted shownWidgetCount on widget children).
+	if (tip:IsForbidden()) or (LibFroznFunctions:IsSecretValue(tip:GetWidth())) or (LibFroznFunctions:HasTipTaintedWidgetContainer(tip)) then
+		return;
+	end
+	
 	-- display tip's bars (in opposite vertical direction)
 	currentDisplayParams.extraPaddingBottomForBars = 0;
 	
@@ -262,6 +270,15 @@ function ttBars:SetupUnitTipsBars(tip)
 	
 	if (cfg.healthBar) then
 		offsetY = self:DisplayUnitTipsBar(self.barPools.healthBarsPool, frameParams, tip, unitRecord, offsetY);
+	end
+	
+	-- account for the initial bottom anchor margin. bars start at
+	-- TT_GTT_BARS_MARGIN_Y from the bottom edge, but each bar only adds
+	-- barHeight + TT_GTT_BARS_SPACING to extraPaddingBottomForBars. the
+	-- difference between the margin and the spacing must be included so the
+	-- first bar's top edge doesn't extend into the text content area.
+	if (currentDisplayParams.extraPaddingBottomForBars > 0) then
+		currentDisplayParams.extraPaddingBottomForBars = currentDisplayParams.extraPaddingBottomForBars + (TT_GTT_BARS_MARGIN_Y - TT_GTT_BARS_SPACING);
 	end
 end
 

--- a/TipTac/modules/ttBars.lua
+++ b/TipTac/modules/ttBars.lua
@@ -259,6 +259,12 @@ function ttBars:DisplayUnitTipsBar(barsPool, frameParams, tip, unitRecord, offse
 	local newOffsetY = offsetY;
 	
 	if (bar:GetVisibility(tip, unitRecord)) then
+		-- The first visible bar needs to reserve the initial bottom anchor margin as well,
+		-- otherwise the tooltip's last text line can overlap the top of the bar stack.
+		if (frameParams.currentDisplayParams.extraPaddingBottomForBars == 0) then
+			frameParams.currentDisplayParams.extraPaddingBottomForBars = TT_GTT_BARS_MARGIN_Y - TT_GTT_BARS_SPACING;
+		end
+		
 		-- initialize anchoring position and color
 		bar:ClearAllPoints();
 		

--- a/TipTac/modules/ttStyle.lua
+++ b/TipTac/modules/ttStyle.lua
@@ -940,7 +940,11 @@ function ttStyle:ModifyUnitTooltip(tip, currentDisplayParams, unitRecord, first)
 		if (currentDisplayParams.mergeLevelLineWithGuildName) then
 			local gttLineText = gttLine:GetText();
 			
-			gttLine:SetText((gttLineText) and (gttLineText ~= " ") and (gttLineText .. "\n" .. tipLineLevelText) or tipLineLevelText);
+			if (LibFroznFunctions:IsSecretValue(gttLineText)) then
+				gttLine:SetText(tipLineLevelText);
+			else
+				gttLine:SetText((gttLineText) and (gttLineText ~= " ") and (gttLineText .. "\n" .. tipLineLevelText) or tipLineLevelText);
+			end
 		else
 			gttLine:SetText(tipLineLevelText);
 		end

--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -227,7 +227,7 @@ local TT_DefaultConfig = {
 	
 	-- icons
 	enableIcons = true,
-	iconUnitIsSecretValue = true,
+	iconUnitIsSecretValue = false,
 	iconRaid = true,
 	iconFaction = false,
 	iconCombat = false,

--- a/TipTac/ttCore.lua
+++ b/TipTac/ttCore.lua
@@ -2444,16 +2444,16 @@ function tt:SetScaleToTip(tip, noFireGroupEvent)
 		
 		local leftOffset, rightOffset, topOffset, bottomOffset = tip:GetClampRectInsets();
 		
-		if (leftOffset) then
+		if (leftOffset) and (not LibFroznFunctions:IsSecretValue(leftOffset)) then
 			tipWidthWithNewScaling = tipWidthWithNewScaling + leftOffset * newTipEffectiveScale;
 		end
-		if (rightOffset) then
+		if (rightOffset) and (not LibFroznFunctions:IsSecretValue(rightOffset)) then
 			tipWidthWithNewScaling = tipWidthWithNewScaling + rightOffset * newTipEffectiveScale;
 		end
-		if (topOffset) then
+		if (topOffset) and (not LibFroznFunctions:IsSecretValue(topOffset)) then
 			tipHeightWithNewScaling = tipHeightWithNewScaling + topOffset * newTipEffectiveScale;
 		end
-		if (bottomOffset) then
+		if (bottomOffset) and (not LibFroznFunctions:IsSecretValue(bottomOffset)) then
 			tipHeightWithNewScaling = tipHeightWithNewScaling + bottomOffset * newTipEffectiveScale;
 		end
 		
@@ -3567,7 +3567,9 @@ LibFroznFunctions:RegisterForGroupEvents(MOD_NAME, {
 		-- set original left/right/top/bottom offset for preventing additional elements from moving off-screen
 		local leftOffset, rightOffset, topOffset, bottomOffset = tip:GetClampRectInsets();
 		
-		if (leftOffset) and (rightOffset) and (topOffset) and (bottomOffset) then
+		if (leftOffset) and (rightOffset) and (topOffset) and (bottomOffset) and
+				(not LibFroznFunctions:IsSecretValue(leftOffset)) and (not LibFroznFunctions:IsSecretValue(rightOffset)) and
+				(not LibFroznFunctions:IsSecretValue(topOffset)) and (not LibFroznFunctions:IsSecretValue(bottomOffset)) then
 			frameParams.originalOffsetsForPreventingOffScreenAvailable = true;
 			frameParams.originalLeftOffsetForPreventingOffScreen, frameParams.originalRightOffsetForPreventingOffScreen, frameParams.originalTopOffsetForPreventingOffScreen, frameParams.originalBottomOffsetForPreventingOffScreen = leftOffset, rightOffset, topOffset, bottomOffset;
 		end

--- a/TipTacItemRef/TipTacItemRef.toc
+++ b/TipTacItemRef/TipTacItemRef.toc
@@ -1,9 +1,9 @@
 ## Interface: 120001
-## Version: 26.03.16.1
+## Version: 26.03.16.2
 ## IconTexture: Interface\AddOns\TipTacItemRef\media\tiptac_logo
-## Title: TipTacItemRef (Local Fix)
+## Title: TipTacItemRef (Temp fix)
 ## Author: Frozn45, Aezay (Earthen Ring EU)
-## Notes: Improved ItemRefTooltip - local fix for Midnight secret tooltip errors
+## Notes: Improved ItemRefTooltip - Temporary fix for Midnight secret tooltip errors
 ## Category-enUS: User Interface
 ## Category-deDE: Benutzerinterface
 ## Category-esES: Interfaz de usuario

--- a/TipTacItemRef/TipTacItemRef.toc
+++ b/TipTacItemRef/TipTacItemRef.toc
@@ -1,9 +1,9 @@
 ## Interface: 120001
-## Version: 26.03.16
+## Version: 26.03.16.1
 ## IconTexture: Interface\AddOns\TipTacItemRef\media\tiptac_logo
-## Title: TipTacItemRef
+## Title: TipTacItemRef (Local Fix)
 ## Author: Frozn45, Aezay (Earthen Ring EU)
-## Notes: Improved ItemRefTooltip
+## Notes: Improved ItemRefTooltip - local fix for Midnight secret tooltip errors
 ## Category-enUS: User Interface
 ## Category-deDE: Benutzerinterface
 ## Category-esES: Interfaz de usuario

--- a/TipTacItemRef/ttItemRef.lua
+++ b/TipTacItemRef/ttItemRef.lua
@@ -20,6 +20,20 @@ local ejtt = EncounterJournalTooltip;
 -- get libs
 local LibFroznFunctions = LibStub:GetLibrary("LibFroznFunctions-1.0");
 
+local function GetNonSecretText(fontString)
+	if (not fontString) then
+		return nil;
+	end
+	
+	local text = fontString:GetText();
+	
+	if (LibFroznFunctions:IsSecretValue(text)) then
+		return nil;
+	end
+	
+	return text;
+end
+
 local function C_CurrencyInfo_GetCurrencyLink(currencyID, currencyAmount)
 	local _currencyAmount = (currencyAmount or 0);
 	
@@ -758,8 +772,8 @@ local function SetAction_Hook(self, slot)
 		local actionType, id, subType = GetActionInfo(slot);
 		if (actionType == "spell" and subType == "pet") then
 			local line = _G[self:GetName().."TextLeft1"]; -- id is always 0. as a workaround find pet action in pet spell book by name.
-			local name = line and (line:GetText() or "");
-			if (not LibFroznFunctions:IsSecretValue(name)) and (name ~= "") and (PetHasSpellbook()) then
+			local name = GetNonSecretText(line) or "";
+			if (name ~= "") and (PetHasSpellbook()) then
 				local numPetSpells, petToken = LibFroznFunctions:HasPetSpells(); -- returns numPetSpells = nil for feral spirit (shaman wolves) in wotlkc
 				
 				if (numPetSpells) then
@@ -845,7 +859,7 @@ local function SetAction_Hook(self, slot)
 				end
 			elseif (subType == "item") then
 				local line = _G[self:GetName().."TextLeft1"]; -- id is wrong. as a workaround find item in macro by name.
-				local name = line and (line:GetText() or "");
+				local name = GetNonSecretText(line) or "";
 				if (name ~= "") then
 					local _, link = GetItemInfo(name);
 					if (link) then
@@ -867,7 +881,7 @@ local function SetAction_Hook(self, slot)
 				end
 			elseif (subType == "MOUNT") then
 				local line = _G[self:GetName().."TextLeft1"]; -- id is wrong. as a workaround find spell in macro by name.
-				local name = line and (line:GetText() or "");
+				local name = GetNonSecretText(line) or "";
 				if (name ~= "") then
 					local link = LibFroznFunctions:GetSpellLink(name);
 					if (link) then
@@ -1667,7 +1681,7 @@ local function TEM_ShowCurrencyTooltip_Hook(self)
 		if (hideClickForSettingsTextInCurrencyTip) then
 			for i = 2, gtt:NumLines() do
 				local gttLine = _G["GameTooltipTextLeft" .. i];
-				local gttLineText = gttLine:GetText();
+				local gttLineText = GetNonSecretText(gttLine);
 				
 				if (type(gttLineText) == "string") then
 					local isGttLineTextCurrencyButtonTooltipClickInstruction = (hideClickForSettingsTextInCurrencyTip) and (gttLineText == CURRENCY_BUTTON_TOOLTIP_CLICK_INSTRUCTION);
@@ -2647,7 +2661,8 @@ function LinkTypeFuncs:item(link, linkType, id)
 					-- remove level from embedded tip
 					for i = 2, min(targetTooltip:NumLines(), LibItemString.TOOLTIP_MAXLINE_LEVEL) do
 						local line = _G[targetTooltip:GetName().."TextLeft"..i];
-						if (line and (line:GetText() or ""):match(ITEM_LEVEL_PLUS)) then
+						local lineText = GetNonSecretText(line);
+						if (lineText) and (lineText:match(ITEM_LEVEL_PLUS)) then
 							line:SetText(nil);
 							break;
 						end
@@ -2655,7 +2670,8 @@ function LinkTypeFuncs:item(link, linkType, id)
 				else 
 					-- remove level from tip's line pool
 					for line in self.linePool:EnumerateActive() do
-						if (line and (line:GetText() or ""):match(ITEM_LEVEL_PLUS)) then
+						local lineText = GetNonSecretText(line);
+						if (lineText) and (lineText:match(ITEM_LEVEL_PLUS)) then
 							local linePredecessorPoint, linePredecessorRelativeTo, linePredecessorRelativePoint, linePredecessorXOfs, linePredecessorYOfs = line:GetPoint(1);
 							
 							if (line == self.textLineAnchor) then
@@ -2698,7 +2714,8 @@ function LinkTypeFuncs:item(link, linkType, id)
 			else
 				for i = 2, min(self:NumLines(),LibItemString.TOOLTIP_MAXLINE_LEVEL) do
 					local line = _G[self:GetName().."TextLeft"..i];
-					if (line and (line:GetText() or ""):match(ITEM_LEVEL_PLUS)) then
+					local lineText = GetNonSecretText(line);
+					if (lineText) and (lineText:match(ITEM_LEVEL_PLUS)) then
 						line:SetText(nil);
 						break;
 					end
@@ -3158,8 +3175,8 @@ function LinkTypeFuncs:achievement(link, linkType, achievementID, guid, complete
 		for i = 6, self:NumLines() do
 			local left = _G[tipName.."TextLeft"..i];
 			local right = _G[tipName.."TextRight"..i];
-			local leftText = left:GetText();
-			local rightText = right:GetText();
+			local leftText = GetNonSecretText(left);
+			local rightText = GetNonSecretText(right);
 			if (leftText and leftText ~= " ") then
 				tinsert(criteriaList, { label = leftText, done = left:GetTextColor() < 0.5 });
 				if (criteriaList[#criteriaList].done) then
@@ -3174,7 +3191,7 @@ function LinkTypeFuncs:achievement(link, linkType, achievementID, guid, complete
 			end
 		end
 		-- Cache Info
-		local progressText = _G[tipName.."TextLeft3"]:GetText() or "";
+		local progressText = GetNonSecretText(_G[tipName.."TextLeft3"]) or "";
 		-- Rebuild Tip
 		self:ClearLines();
 		local stat = isPlayer and GetStatistic(achievementID);
@@ -3317,7 +3334,8 @@ function LinkTypeFuncs:battlepet(link, linkType, speciesID, level, breedQuality,
 				
 				-- remove level from tip's line pool
 				for line in self.linePool:EnumerateActive() do
-					if (line and (line:GetText() or ""):match(BATTLE_PET_CAGE_TOOLTIP_LEVEL)) then
+					local lineText = GetNonSecretText(line);
+					if (lineText) and (lineText:match(BATTLE_PET_CAGE_TOOLTIP_LEVEL)) then
 						local linePredecessorPoint, linePredecessorRelativeTo, linePredecessorRelativePoint, linePredecessorXOfs, linePredecessorYOfs = line:GetPoint(1);
 						
 						if (line == self.textLineAnchor) then
@@ -3359,7 +3377,8 @@ function LinkTypeFuncs:battlepet(link, linkType, speciesID, level, breedQuality,
 			elseif (self ~= pbputt) then
 				for i = 2, min(self:NumLines(),LibItemString.TOOLTIP_MAXLINE_LEVEL) do
 					local line = _G[self:GetName().."TextLeft"..i];
-					if (line and (line:GetText() or ""):match(BATTLE_PET_CAGE_TOOLTIP_LEVEL)) then
+					local lineText = GetNonSecretText(line);
+					if (lineText) and (lineText:match(BATTLE_PET_CAGE_TOOLTIP_LEVEL)) then
 						line:SetText(nil);
 						break;
 					end
@@ -3462,7 +3481,8 @@ function LinkTypeFuncs:conduit(link, linkType, conduitID, conduitRank)
 		if (showLevel) then
 			for i = 2, min(self:NumLines(),LibItemString.TOOLTIP_MAXLINE_LEVEL) do
 				local line = _G[self:GetName().."TextLeft"..i];
-				if (line and (line:GetText() or ""):match(ITEM_LEVEL_PLUS)) then
+				local lineText = GetNonSecretText(line);
+				if (lineText) and (lineText:match(ITEM_LEVEL_PLUS)) then
 					line:SetText(nil);
 					break;
 				end


### PR DESCRIPTION
Workaround to fix issues that is happening with the addon after the March 26th small patch:
- Switch to Blizzard default tooltip when targeting enemies in an instance
- Attempt to fix an issue about having an overlap item of the tooltip (health bar) on top of the information above

Didn't fully tested if affected any other feature