### PR TITLE
Guard unit speed display against secret values

### DIFF
--- a/TipTac/modules/ttStyle.lua
+++ b/TipTac/modules/ttStyle.lua
@@ -620,7 +620,7 @@ function ttStyle:ModifyUnitTooltip(tip, currentDisplayParams, unitRecord, first)
 	-- Current Unit Speed
 	if (cfg.showCurrentUnitSpeed) then
 		local currentUnitSpeed = GetUnitSpeed(unitRecord.id);
-		if (currentUnitSpeed > 0) then
+		if (not LibFroznFunctions:IsSecretValue(currentUnitSpeed)) and (currentUnitSpeed > 0) then
 			lineLevel:Push(" " .. CreateAtlasMarkup("glueannouncementpopup-arrow"));
 			lineLevel:Push(TT_COLOR.text.unitSpeed:WrapTextInColorCode(format("%.0f%%", currentUnitSpeed / BASE_MOVEMENT_SPEED * 100)));
 		end


### PR DESCRIPTION
## Summary
- guard TipTac's current-unit-speed tooltip display against secret values returned by WoW
- avoid comparing or formatting GetUnitSpeed(unit) when the value is protected
- preserve existing behavior when the speed value is usable

## Why
Recent WoW changes can return secret values from GetUnitSpeed(unit) in some situations. TipTac already guards other tooltip fields with LibFroznFunctions:IsSecretValue(...), but the current unit speed block compared the raw value directly, which can throw a Lua error while tooltip code is tainted.

## Testing
- reproduced the error in-game from the installed addon copy
- applied the same minimal guard in the repo checkout
- no automated tests available for this addon
