### PR TITLE
Fix secret value crash on GetUnitSpeed (WoW 12.0.5)

### DIFF
--- a/TipTac/TipTac.toc
+++ b/TipTac/TipTac.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120005
 ## Version: 26.04.18
 ## IconTexture: Interface\AddOns\TipTac\media\tiptac_logo
 ## Title: TipTac

--- a/TipTac/modules/ttStyle.lua
+++ b/TipTac/modules/ttStyle.lua
@@ -620,7 +620,7 @@ function ttStyle:ModifyUnitTooltip(tip, currentDisplayParams, unitRecord, first)
 	-- Current Unit Speed
 	if (cfg.showCurrentUnitSpeed) then
 		local currentUnitSpeed = GetUnitSpeed(unitRecord.id);
-		if (currentUnitSpeed > 0) then
+		if (not LibFroznFunctions:IsSecretValue(currentUnitSpeed)) and (currentUnitSpeed > 0) then
 			lineLevel:Push(" " .. CreateAtlasMarkup("glueannouncementpopup-arrow"));
 			lineLevel:Push(TT_COLOR.text.unitSpeed:WrapTextInColorCode(format("%.0f%%", currentUnitSpeed / BASE_MOVEMENT_SPEED * 100)));
 		end

--- a/TipTacItemRef/TipTacItemRef.toc
+++ b/TipTacItemRef/TipTacItemRef.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120005
 ## Version: 26.04.18
 ## IconTexture: Interface\AddOns\TipTacItemRef\media\tiptac_logo
 ## Title: TipTacItemRef

--- a/TipTacOptions/TipTacOptions.toc
+++ b/TipTacOptions/TipTacOptions.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120005
 ## Version: 26.04.18
 ## IconTexture: Interface\AddOns\TipTacOptions\media\tiptac_logo
 ## Title: TipTacOptions

--- a/TipTacTalents/TipTacTalents.toc
+++ b/TipTacTalents/TipTacTalents.toc
@@ -1,4 +1,4 @@
-## Interface: 120001
+## Interface: 120005
 ## Version: 26.04.18
 ## IconTexture: Interface\AddOns\TipTacTalents\media\tiptac_logo
 ## Title: TipTacTalents


### PR DESCRIPTION
## Summary

- WoW Midnight patch 12.0.5 (released 2026-04-22) introduced *secret values* on several unit APIs. `GetUnitSpeed` now returns a secret number for units whose stats are hidden (hostile NPCs, enemy players, etc.), which breaks `ttStyle.lua:623`:

  ```
  ttStyle.lua:623: attempt to compare local 'currentUnitSpeed'
  (a secret number value, while execution tainted by 'TipTac')
  ```

- Guarded the comparison with the existing `LibFroznFunctions:IsSecretValue()` helper, same pattern already used throughout the codebase for health/power.
- Bumped retail TOC `Interface` from `120001` to `120005` on the 4 retail `.toc` files (TipTac, TipTacItemRef, TipTacOptions, TipTacTalents). Classic / TBC / Mists / Vanilla TOCs untouched.

## Reproduction

Mouse over any hostile NPC in a Midnight zone (e.g. *Griffeur écailleux* / Scaly Gripper) with `showCurrentUnitSpeed` enabled → instant taint error.

## Test plan

- [x] `/reload` on 12.0.5 retail, hover hostile NPC → no error, speed line simply hidden when the value is secret.
- [x] Hover friendly/self unit → speed line still displays correctly.
- [x] TOC loads without the "out of date" warning.