### PR TITLE
12.1.0 compatibility: TOC interface bump + fix secret aura taint error

### DIFF
--- a/TipTac/TipTac.toc
+++ b/TipTac/TipTac.toc
@@ -1,5 +1,5 @@
-## Interface: 120007
-## Version: 26.07.16
+## Interface: 120100
+## Version: 26.08.15
 ## IconTexture: Interface\AddOns\TipTac\media\tiptac_logo
 ## Title: TipTac
 ## Author: Frozn45, Aezay (Earthen Ring EU)

--- a/TipTac/modules/ttAuras.lua
+++ b/TipTac/modules/ttAuras.lua
@@ -251,8 +251,17 @@ function ttAuras:DisplayUnitTipsAuras(tip, currentDisplayParams, auraType, start
 			
 			if (cfg.auraStackCount) then
 				if (LibFroznFunctions:IsSecretValue(unitAuraData.applications)) then
-					aura.count:SetText(C_UnitAuras.GetAuraApplicationDisplayCount(unitRecord.id, unitAuraData.auraInstanceID));
-					hideAuraCount = false;
+					-- since 12.1.x (retail): GetAuraApplicationDisplayCount() takes only the aura instance, the unit argument has been removed.
+					-- classic flavors (and the documented API) still expect (auraInstanceUnit, auraInstanceID). try the new signature first, fall back to the old one.
+					-- pcall also guards against secret aura instance IDs (see LibFroznFunctions:GetAuraDataByIndex for the same workaround).
+					local success, count = pcall(C_UnitAuras.GetAuraApplicationDisplayCount, unitAuraData.auraInstanceID);
+					if (not success) then
+						success, count = pcall(C_UnitAuras.GetAuraApplicationDisplayCount, unitRecord.id, unitAuraData.auraInstanceID);
+					end
+					if (success) and (count) then
+						aura.count:SetText(count);
+						hideAuraCount = false;
+					end
 				elseif (unitAuraData.applications) and (unitAuraData.applications > 1) then
 					aura.count:SetText(unitAuraData.applications);
 					hideAuraCount = false;

--- a/TipTac/modules/ttIcons.lua
+++ b/TipTac/modules/ttIcons.lua
@@ -132,8 +132,11 @@ function ttIcons:DisplayTipsIcon(tip, currentDisplayParams, iconType, startingIc
 	local unitRecord = currentDisplayParams.unitRecord;
 	
 	-- unit doesn't exist
-	if (unitRecord ~= LFF_UNIT_RECORD.SecretValue) and (not UnitExists(unitRecord.id)) then
-		return 0;
+	if (unitRecord ~= LFF_UNIT_RECORD.SecretValue) then
+		local unitExists = UnitExists(unitRecord.id);
+		if (not LibFroznFunctions:IsSecretValue(unitExists)) and (not unitExists) then
+			return 0;
+		end
 	end
 	
 	-- display tip's "unit is a secret value" icon
@@ -159,7 +162,8 @@ function ttIcons:DisplayTipsIcon(tip, currentDisplayParams, iconType, startingIc
 		if (iconType == "RAID") then
 			local raidIconIndex = GetRaidTargetIndex(unitRecord.id);
 			
-			if (raidIconIndex) then
+			-- soft-interact units can return secret values from unit queries (e.g. "softinteract" in the 12.x soft target system)
+			if (not LibFroznFunctions:IsSecretValue(raidIconIndex)) and (raidIconIndex) then
 				-- acquire icon frame
 				iconFrameIndex = iconFrameIndex + 1;
 				
@@ -175,7 +179,10 @@ function ttIcons:DisplayTipsIcon(tip, currentDisplayParams, iconType, startingIc
 		
 		-- display tip's faction icon
 		elseif (iconType == "FACTION") then
-			if (UnitIsPVPFreeForAll(unitRecord.id)) then
+			-- soft-interact units can return secret booleans from unit queries (e.g. "softinteract" in the 12.x soft target system)
+			local isPVPFFA = UnitIsPVPFreeForAll(unitRecord.id);
+			local isPVP = UnitIsPVP(unitRecord.id);
+			if (not LibFroznFunctions:IsSecretValue(isPVPFFA)) and (isPVPFFA) then
 				-- acquire icon frame
 				iconFrameIndex = iconFrameIndex + 1;
 				
@@ -187,11 +194,11 @@ function ttIcons:DisplayTipsIcon(tip, currentDisplayParams, iconType, startingIc
 				-- set icon
 				icon.icon:SetTexture("Interface\\TargetingFrame\\UI-PVP-FFA");
 				icon.icon:SetTexCoord(0, 0.62, 0, 0.62);
-			elseif (UnitIsPVP(unitRecord.id)) then
+			elseif (not LibFroznFunctions:IsSecretValue(isPVP)) and (isPVP) then
 				-- set icon if faction isn't neutral
 				local englishFaction = UnitFactionGroup(unitRecord.id);
 				
-				if (englishFaction) and (englishFaction ~= "Neutral") then
+				if (not LibFroznFunctions:IsSecretValue(englishFaction)) and (englishFaction) and (englishFaction ~= "Neutral") then
 					-- acquire icon frame
 					iconFrameIndex = iconFrameIndex + 1;
 					
@@ -208,7 +215,8 @@ function ttIcons:DisplayTipsIcon(tip, currentDisplayParams, iconType, startingIc
 		
 		-- display tip's combat icon
 		elseif (iconType == "COMBAT") then
-			if (UnitAffectingCombat(unitRecord.id)) then
+			local isAffectingCombat = UnitAffectingCombat(unitRecord.id);
+			if (not LibFroznFunctions:IsSecretValue(isAffectingCombat)) and (isAffectingCombat) then
 				-- acquire icon frame
 				iconFrameIndex = iconFrameIndex + 1;
 				

--- a/TipTac/modules/ttStyle.lua
+++ b/TipTac/modules/ttStyle.lua
@@ -203,7 +203,8 @@ local function AddTarget(lineList,target,targetName)
 	else
 		local targetReactionColor = CreateColor(unpack(cfg["colorReactText"..LibFroznFunctions:GetUnitReactionIndex(target)]));
 		lineList:Push(targetReactionColor:WrapTextInColorCode("["));
-		if (UnitIsPlayer(target)) then
+		local isTargetPlayer = UnitIsPlayer(target);
+		if (not LibFroznFunctions:IsSecretValue(isTargetPlayer)) and (isTargetPlayer) then
 			local targetClassID = select(3, UnitClass(target));
 			local targetClassColor = LibFroznFunctions:GetClassColor(targetClassID, nil, cfg.enableCustomClassColors and TT_ExtendedConfig.customClassColors or nil) or TT_COLOR.text.targeting;
 			lineList:Push(targetClassColor:WrapTextInColorCode(targetName));
@@ -265,7 +266,8 @@ function ttStyle:GenerateTargetedByLines(unitRecord)
 			if (not LibFroznFunctions:IsSecretValue(isPlayerUnit)) and (not isPlayerUnit) then
 				local unitName = UnitName(unit);
 				
-				if (UnitIsPlayer(unit)) then
+				local isUnitPlayer = UnitIsPlayer(unit);
+				if (not LibFroznFunctions:IsSecretValue(isUnitPlayer)) and (isUnitPlayer) then
 					local unitClassID = select(3, UnitClass(unit));
 					local unitClassColor = LibFroznFunctions:GetClassColor(unitClassID, nil, cfg.enableCustomClassColors and TT_ExtendedConfig.customClassColors or nil) or TT_COLOR.text.targetedBy;
 					lineTargetedBy:Push(unitClassColor:WrapTextInColorCode(unitName));
@@ -590,7 +592,8 @@ function ttStyle:ModifyUnitTooltip(tip, currentDisplayParams, unitRecord, first)
 	unitRecord.nameColor = ((not cfg.enableColorName) and CreateColor(GameTooltipTextLeft1:GetTextColor())) or (cfg.colorNameByReaction and unitRecord.reactionColor) or CreateColor(unpack(cfg.colorName));
 
 	-- this is the line index where the level and unit type info is
-	lineLevel.Index = 2 + (unitRecord.isColorBlind and UnitIsVisible(unitRecord.id) and 1 or 0);
+	local unitIsVisible = UnitIsVisible(unitRecord.id);
+	lineLevel.Index = 2 + (unitRecord.isColorBlind and (not LibFroznFunctions:IsSecretValue(unitIsVisible)) and (unitIsVisible) and 1 or 0);
 	
 	-- remove unwanted lines from tip
 	self:RemoveUnwantedLinesFromTip(tip, unitRecord);
@@ -601,7 +604,10 @@ function ttStyle:ModifyUnitTooltip(tip, currentDisplayParams, unitRecord, first)
 	end
 	
 	-- Level + Classification
-	lineLevel:Push(((UnitCanAttack(unitRecord.id, "player") or UnitCanAttack("player", unitRecord.id)) and LibFroznFunctions:GetDifficultyColorForUnit(unitRecord.id) or CreateColor(unpack(cfg.colorLevel))):WrapTextInColorCode((cfg["classification_".. (unitRecord.classification or "")] or "%s? "):format(unitRecord.level == -1 and "??" or unitRecord.level)));
+	local unitCanAttackUnit = UnitCanAttack(unitRecord.id, "player");
+	local unitCanBeAttacked = UnitCanAttack("player", unitRecord.id);
+	local canAttack = ((not LibFroznFunctions:IsSecretValue(unitCanAttackUnit)) and (unitCanAttackUnit)) or ((not LibFroznFunctions:IsSecretValue(unitCanBeAttacked)) and (unitCanBeAttacked));
+	lineLevel:Push((canAttack and LibFroznFunctions:GetDifficultyColorForUnit(unitRecord.id) or CreateColor(unpack(cfg.colorLevel))):WrapTextInColorCode((cfg["classification_".. (unitRecord.classification or "")] or "%s? "):format(unitRecord.level == -1 and "??" or unitRecord.level)));
 	
 	-- Reaction Icon
 	if (cfg.reactIcon) and (TT_ReactionIcon[unitRecord.reactionIndex]) then

--- a/TipTacItemRef/TipTacItemRef.toc
+++ b/TipTacItemRef/TipTacItemRef.toc
@@ -1,5 +1,5 @@
-## Interface: 120007
-## Version: 26.07.16
+## Interface: 120100
+## Version: 26.08.15
 ## IconTexture: Interface\AddOns\TipTacItemRef\media\tiptac_logo
 ## Title: TipTacItemRef
 ## Author: Frozn45, Aezay (Earthen Ring EU)

--- a/TipTacItemRef/ttItemRef.lua
+++ b/TipTacItemRef/ttItemRef.lua
@@ -699,9 +699,12 @@ end
 
 -- HOOK: SetUnitAuraByAuraInstanceID + SetUnitBuffByAuraInstanceID + SetUnitDebuffByAuraInstanceID
 local function SetUnitAuraByAuraInstanceID_Hook(self, unit, auraInstanceID, filter)
-	if (cfg.if_enable) and (not tipDataAdded[self]) then
-		local aura = C_UnitAuras.GetAuraDataByAuraInstanceID(unit, auraInstanceID);
-		if (aura) then
+	-- since mn 12.1.0: CooldownViewer passes nameplate-only aura instance IDs on "player" whose aura access is restricted.
+	-- GetAuraDataByAuraInstanceID() errors with "Auras cannot be accessed when secret while tainted" if called from tainted code,
+	-- even with a non-secret instance ID (see "GetAuraDataByIndex" in LibFroznFunctions for the same workaround).
+	if (cfg.if_enable) and (not tipDataAdded[self]) and (not LibFroznFunctions:IsSecretValue(auraInstanceID)) then
+		local success, aura = pcall(C_UnitAuras.GetAuraDataByAuraInstanceID, unit, auraInstanceID);
+		if (success) and (aura) then
 			local spellID = aura.spellId;
 			local source = aura.sourceUnit;
 			if (spellID) then

--- a/TipTacItemRef/ttItemRef.lua
+++ b/TipTacItemRef/ttItemRef.lua
@@ -1775,11 +1775,18 @@ local function WCFICF_RefreshAppearanceTooltip_Hook(self)
 		local wardrobeCollectionFrame = itemsCollectionFrame:GetParent();
 		if (wardrobeCollectionFrame.tooltipSourceIndex) then
 			local sources = CollectionWardrobeUtil.GetSortedAppearanceSources(self.tooltipVisualID, itemsCollectionFrame:GetActiveCategory(), itemsCollectionFrame.transmogLocation);
-			local index = CollectionWardrobeUtil.GetValidIndexForNumSources(wardrobeCollectionFrame.tooltipSourceIndex, #sources);
-			local sourceID = sources[index].sourceID;
 			
-			tipDataAdded[gtt] = "transmogappearance";
-			LinkTypeFuncs.transmogappearance(gtt, nil, "transmogappearance", sourceID);
+			-- since mn 12.1.0: the sources list can be empty when swapping classes in the collections panel, which makes GetValidIndexForNumSources() return an invalid index (see the same guard in WardrobeItemsCollectionMixin:RefreshAppearanceTooltip() in "Blizzard_Wardrobe.lua").
+			if (#sources > 0) then
+				local index = CollectionWardrobeUtil.GetValidIndexForNumSources(wardrobeCollectionFrame.tooltipSourceIndex, #sources);
+				local source = sources[index];
+				if (source) then
+					local sourceID = source.sourceID;
+
+					tipDataAdded[gtt] = "transmogappearance";
+					LinkTypeFuncs.transmogappearance(gtt, nil, "transmogappearance", sourceID);
+				end
+			end
 		end
 	end
 end

--- a/TipTacOptions/TipTacOptions.toc
+++ b/TipTacOptions/TipTacOptions.toc
@@ -1,5 +1,5 @@
-## Interface: 120007
-## Version: 26.07.16
+## Interface: 120100
+## Version: 26.08.15
 ## IconTexture: Interface\AddOns\TipTacOptions\media\tiptac_logo
 ## Title: TipTacOptions
 ## Author: Frozn45, Aezay (Earthen Ring EU)

--- a/TipTacTalents/TipTacTalents.toc
+++ b/TipTacTalents/TipTacTalents.toc
@@ -1,5 +1,5 @@
-## Interface: 120007
-## Version: 26.07.16
+## Interface: 120100
+## Version: 26.08.15
 ## IconTexture: Interface\AddOns\TipTacTalents\media\tiptac_logo
 ## Title: TipTacTalents
 ## Author: Frozn45, Aezay (Earthen Ring EU)


### PR DESCRIPTION
Changes to make the addon work on the current 12.1.x ("Midnight") client:

**1. TOC interface bump 120007 → 120100** (`TipTac.toc`, `TipTacItemRef.toc`, `TipTacOptions.toc`, `TipTacTalents.toc`)

**2. Fix Lua taint error in TipTacItemRef** (`ttItemRef.lua`, `SetUnitAuraByAuraInstanceID_Hook`)

`Blizzard_CooldownViewer` (`CooldownViewerItemData.lua:1015`) calls `GameTooltip:SetUnitAuraByAuraInstanceID(unit, auraInstanceID, "INCLUDE_NAME_PLATE_ONLY")` with instance IDs of nameplate-only auras on "player" whose aura access is restricted. Calling `C_UnitAuras.GetAuraDataByAuraInstanceID()` on those from tainted code errors with:

```
GetAuraDataByAuraInstanceID(): Auras cannot be accessed when secret while tainted by 'TipTacItemRef'
```

Notes:
- The instance ID is not always wrapped as a secret value (observed both `<secret number>` and a plain number for the same failure), so `IsSecretValue()` alone is not sufficient — the pcall guard is required. This mirrors the existing workaround in `LibFroznFunctions:GetAuraDataByIndex`.
- The same hook covers `SetUnitBuffByAuraInstanceID` / `SetUnitDebuffByAuraInstanceID`, so all three paths are fixed.

**3. Fix `C_UnitAuras.GetAuraApplicationDisplayCount()` signature change** (`TipTac/modules/ttAuras.lua:254`)

The current client's usage is `GetAuraApplicationDisplayCount(auraInstance [, minDisplayCount, maxDisplayCount])` — the unit argument was removed:

```
bad argument #1 to '?' (Usage: local count = C_UnitAuras.GetAuraApplicationDisplayCount(auraInstance [, minDisplayCount, maxDisplayCount]))
```

The call now passes only `unitAuraData.auraInstanceID`, with a pcall fallback to the old `(unit, auraInstanceID)` form for classic flavors — both dumped docs (12.0.7 and 12.1.0) still document the 4-argument form, so the classic clients likely still expect it. The engine's runtime argument validation is authoritative for the current client; the fallback keeps every flavor working. Secret instance IDs are pcall-guarded (same pattern as `LibFroznFunctions:GetAuraDataByIndex`).

**4. Fix Lua error in the wardrobe appearance tooltip hook** (`TipTacItemRef/ttItemRef.lua`, `WCFICF_RefreshAppearanceTooltip_Hook`)

```
TipTacItemRef/ttItemRef.lua:1779: attempt to index field '?' (a nil value)
```

When swapping classes in the Collections panel, `CollectionWardrobeUtil.GetSortedAppearanceSources()` can return an empty list; `GetValidIndexForNumSources(index, 0)` then computes `mod(x, 0)` → NaN, and `sources[NaN]` is nil. 12.1.0's `WardrobeItemsCollectionMixin:RefreshAppearanceTooltip()` guards this exact case (`if #sources == 0 then return end`); the hook now mirrors that guard and additionally nil-checks the resolved source.

All other APIs used by the addon were verified present/unchanged against the 12.1.0 dump (tooltip frame APIs, `C_*` namespaces, hooked FrameXML globals).

Verified: `luac -p` passes for all changed files; fixes 1-3 confirmed in-game (no further errors on the previously failing paths). Fix 4 (wardrobe hook) is defensive against the class-swap race and pending in-game confirmation.

**5. Fix Lua errors for soft-interact units with secret values** (`TipTac/modules/ttIcons.lua`, `TipTac/modules/ttStyle.lua`)

```
13x TipTac/modules/ttIcons.lua:190: attempt to perform boolean test on a secret boolean value (execution tainted by 'TipTac')
```

The 12.x soft target system exposes a `"softinteract"` unit token whose data is restricted: health/power and PvP state come back as **secret values** to addon code. Direct boolean tests (`UnitIsPVP`, `UnitIsPVPFreeForAll`, `UnitAffectingCombat`, `UnitIsPlayer`, `UnitIsVisible`, `UnitCanAttack`, `UnitExists`, `GetRaidTargetIndex`) now error on such units. Guarded all of them with the existing `LibFroznFunctions:IsSecretValue()` pattern (`(not IsSecretValue(x)) and (x)`), which is a no-op for normal values, so classic flavors are unaffected. PvP/faction/combat icons and the level line are simply omitted when the value is secret.
